### PR TITLE
Skip epochs where no position tracking info sooner

### DIFF
--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -777,8 +777,8 @@ def add_position(
             ].full_path.to_list()[0]
 
         except IndexError:
-            position_tracking_filepath = None
-            position_timestamps_filepath = None
+            logging.warning(f"No position tracking data found for epoch {epoch}")
+            continue
 
         logger.info(epoch)
         logger.info(f"\tposition_timestamps_filepath: {position_timestamps_filepath}")


### PR DESCRIPTION
Previous changes made to avoid inserting empty spatial series in epochs without tracking data.  This PR simplifies that case by continuing past the epoch as soon as fail to load needed position tracking info.  Avoids later errors in non-ptp datasets for non position tracking epochs.