### PR TITLE
Analog multiplex select bug

### DIFF
--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -4,9 +4,9 @@ import numpy as np
 import pynwb
 from hdmf.backends.hdf5 import H5DataIO
 from pynwb import NWBFile
-from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 
 from trodes_to_nwb import convert_rec_header
+from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 
 
 def add_analog_data(
@@ -53,7 +53,7 @@ def add_analog_data(
     # by studies by the NWB team.
     # could also add compression here. zstd/blosc-zstd are recommended by the NWB team, but
     # they require the hdf5plugin library to be installed. gzip is available by default.
-    data_data_io = H5DataIO(rec_dci, chunks=(16384, min(rec_dci.n_channel, 32)))
+    data_data_io = H5DataIO(rec_dci, chunks=(16384, min(len(analog_channel_ids), 32)))
 
     # make the objects to add to the nwb file
     nwbfile.create_processing_module(

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -232,8 +232,8 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             ):  # if multiplexed channels are being requested
                 requested_multiplex = np.arange(n_multiplex) + n_analog_selected
                 multiplex_slice = slice(
-                    selection[1].start - n_analog,
-                    selection[1].stop - n_analog,
+                    max(selection[1].start - n_analog, 0),
+                    max(selection[1].stop - n_analog, 0),
                     selection[1].step,
                 )
                 requested_multiplex = requested_multiplex[multiplex_slice]

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -216,7 +216,7 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         if (
             self.neo_io[0].header["signal_streams"][self.stream_index]["id"]
             == "ECU_analog"
-        ):
+        ) and self.is_analog:
             multiplex_keys = self.neo_io[0].multiplexed_channel_xml.keys()
             n_multiplex = len(multiplex_keys)
             n_analog = (

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -1,11 +1,12 @@
 import os
 
 import pynwb
-from trodes_to_nwb.convert_analog import add_analog_data, get_analog_channel_names
-from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
-from trodes_to_nwb.tests.utils import data_path
 
 from trodes_to_nwb import convert_rec_header, convert_yaml
+from trodes_to_nwb.convert_analog import add_analog_data, get_analog_channel_names
+from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
+from trodes_to_nwb.tests.utils import data_path
 
 
 def test_add_analog_data():
@@ -31,7 +32,7 @@ def test_add_analog_data():
         assert "analog" in read_nwbfile.processing["analog"]["analog"].time_series
         assert read_nwbfile.processing["analog"]["analog"]["analog"].data.chunks == (
             16384,
-            12,
+            22,
         )
 
         with pynwb.NWBHDF5IO(rec_to_nwb_file, "r", load_namespaces=True) as io2:
@@ -68,3 +69,37 @@ def test_add_analog_data():
             ).all()
     # cleanup
     os.remove(filename)
+
+
+def test_selection_of_multiplexed_data():
+    rec_file = data_path / "20230622_sample_01_a1.rec"
+    rec_header = convert_rec_header.read_header(rec_file)
+    hconf = rec_header.find("HardwareConfiguration")
+    ecu_conf = None
+    for conf in hconf:
+        if conf.attrib["name"] == "ECU":
+            ecu_conf = conf
+            break
+    analog_channel_ids = []
+    for channel in ecu_conf:
+        if channel.attrib["dataType"] == "analog":
+            analog_channel_ids.append(channel.attrib["id"])
+    assert (len(analog_channel_ids)) == 12
+    rec_dci = RecFileDataChunkIterator(
+        [rec_file],
+        nwb_hw_channel_order=analog_channel_ids,
+        stream_index=2,
+        is_analog=True,
+    )
+    assert len(rec_dci.neo_io[0].multiplexed_channel_xml.keys()) == 10
+    slice_ind = [(0, 4), (0, 30), (1, 15), (5, 15), (20, 25)]
+    expected_channels = [4, 22, 14, 10, 2]
+    for ind, expected in zip(slice_ind, expected_channels):
+        data = rec_dci._get_data(
+            (
+                slice(0, 100, None),
+                slice(ind[0], ind[1], None),
+            )
+        )
+        assert data.shape[1] == expected
+    return


### PR DESCRIPTION
Fixes #71 
- `RecDataChunkIterator.get_data()` now parses data returned by `SpikegadgetsRawIO._get_data()` to account for concatenated channels from multiplexed data. 
- Performs additional slicing in this case to pull only channels requested by calling this from the hdmf writer
- Adds test for strange slicing cases in the multiplex data
- Increases data chunk size of hdmf writier to include mulitplex channels in the same chunk