### PR TITLE
Switch to use franklab NwbElectrodeGroup extension

### DIFF
--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -6,7 +6,6 @@ from xml.etree import ElementTree
 
 import pandas as pd
 import pytz
-import trodes_to_nwb.metadata_validation
 import yaml
 from hdmf.common.table import DynamicTable, VectorData
 from ndx_franklab_novela import (
@@ -16,11 +15,12 @@ from ndx_franklab_novela import (
     Probe,
     Shank,
     ShanksElectrode,
+    NwbElectrodeGroup,
 )
 from pynwb import NWBFile
-from pynwb.ecephys import ElectrodeGroup
 from pynwb.file import ProcessingModule, Subject
 
+import trodes_to_nwb.metadata_validation
 from trodes_to_nwb import __version__
 
 
@@ -216,10 +216,15 @@ def add_electrode_groups(
             contact_size=probe_meta["contact_size"],
         )
         # make the electrode group with the probe (Do it here so have electrodeGroup object to reference when making electrodes)
-        e_group = ElectrodeGroup(
+        e_group = NwbElectrodeGroup(
             name=str(egroup_metadata["id"]),
             description=egroup_metadata["description"],
-            location=egroup_metadata["targeted_location"],
+            location=egroup_metadata["location"],
+            targeted_location=egroup_metadata["targeted_location"],
+            targeted_x=float(egroup_metadata["targeted_x"]),
+            targeted_y=float(egroup_metadata["targeted_y"]),
+            targeted_z=float(egroup_metadata["targeted_z"]),
+            units=egroup_metadata["units"],
             device=probe,
         )
         nwbfile.add_electrode_group(e_group)

--- a/src/trodes_to_nwb/tests/test_convert_yaml.py
+++ b/src/trodes_to_nwb/tests/test_convert_yaml.py
@@ -106,7 +106,12 @@ def test_electrode_creation():
     for i, group_metadata in enumerate(metadata["electrode_groups"]):
         group = nwbfile.electrode_groups[str(group_metadata["id"])]
         assert group.description == group_metadata["description"]
-        assert group.location == group_metadata["targeted_location"]
+        assert group.location == group_metadata["location"]
+        assert group.targeted_location == group_metadata["targeted_location"]
+        assert group.targeted_x == group_metadata["targeted_x"]
+        assert group.targeted_y == group_metadata["targeted_y"]
+        assert group.targeted_z == group_metadata["targeted_z"]
+        assert group.units == group_metadata["units"]
 
     # Check if the probes were added correctly
     assert len(nwbfile.devices) == len(metadata["electrode_groups"])
@@ -181,7 +186,12 @@ def test_electrode_creation_reconfigured():
     for i, group_metadata in enumerate(metadata["electrode_groups"]):
         group = nwbfile.electrode_groups[str(group_metadata["id"])]
         assert group.description == group_metadata["description"]
-        assert group.location == group_metadata["targeted_location"]
+        assert group.location == group_metadata["location"]
+        assert group.targeted_location == group_metadata["targeted_location"]
+        assert group.targeted_x == group_metadata["targeted_x"]
+        assert group.targeted_y == group_metadata["targeted_y"]
+        assert group.targeted_z == group_metadata["targeted_z"]
+        assert group.units == group_metadata["units"]
 
     # Check if the probes were added correctly
     assert len(nwbfile.devices) == len(metadata["electrode_groups"])


### PR DESCRIPTION
- Fixes #78 
    - changes electrode group to be a franklab extension `NwbElectrodeGroup` object
    - adds additional metadata accepted by this object (targeted_location, targeted_(x,y,z), units)
    - adjusts unit tests
- Resolves #76 
    - data now included in the extension object