### PR TITLE
Non ptp epoch restriction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         },
     },
     "isort.args": [

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Developers should install from source.
 
     These files need to be named in the following format `{date}_{animal}_{epoch}_{tag}.{extension}` where date is in the `YYYYMMDD` format, epoch is an integer with zero padding (e.g. `02` and not `2`), and tag can be any handy short descriptor. For example, `20230622_randy_02_r1.rec` is the recording file for animal randy, second epoch, run 1 (r1) for June 22, 2023.
 
-    (*Note: By default, Trodes saves video-related files (`.h264`, `videoPositionTracking`, `cameraHWSync`) slightly different from this format as `{date}_{animal}_{epoch}_{tag}.{camera number}.{extension}`. This is accepted by this conversion package, and used to match camera to position tracking in epochs with mulitple cameras*)
+    (_Note: By default, Trodes saves video-related files (`.h264`, `videoPositionTracking`, `cameraHWSync`) slightly different from this format as `{date}_{animal}_{epoch}_{tag}.{camera number}.{extension}`. This is accepted by this conversion package, and used to match camera to position tracking in epochs with mulitple cameras_)
 
 2. Create a metadata yaml file for each recording session. We **HIGHLY** recommend using the [NWB YAML Creator](https://lorenfranklab.github.io/rec_to_nwb_yaml_creator/) to create the metadata yaml file to ensure compatability and correct format. You can also see this [example metadata yaml file](src/trodes_to_nwb/tests/test_data/20230622_sample_metadata.yml).
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - franklab
 dependencies:
-- jsonschema=4.19.2
+- jsonschema<4.21.0
 - numpy
 - scipy
 - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pytest-cov
 - pytest-mock
 - pyyaml
-- jsonschema
+- jsonschema=4.19.2
 - ffmpeg
 - pip
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - franklab
 dependencies:
+- jsonschema=4.19.2
 - numpy
 - scipy
 - pandas
@@ -15,7 +16,6 @@ dependencies:
 - pytest-cov
 - pytest-mock
 - pyyaml
-- jsonschema=4.19.2
 - ffmpeg
 - pip
 - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "neo",
     "dask[complete]",
     "ffmpeg",
-    "jsonschema<4.21.0"
+    "jsonschema<4.21.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "neo",
     "dask[complete]",
     "ffmpeg",
-    "jsonschema==4.19.2"
+    "jsonschema<4.21.0"
 ]
 dynamic = ["version"]
 

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -95,6 +95,8 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             iterator_size
         ):  # iterate backwards so can insert new iterators
             if size > MAXIMUM_ITERATOR_SIZE:
+                # calculate systime regression on full epoch, parameters stored and inherited by partial iterators
+                self.neo_io[i].get_regressed_systime(0, None)
                 # split into smaller iterators
                 sub_iterators = []
                 j = 0

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -95,13 +95,13 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             iterator_size
         ):  # iterate backwards so can insert new iterators
             if size > MAXIMUM_ITERATOR_SIZE:
-                # calculate systime regression on full epoch, parameters stored and inherited by partial iterators
-                self.neo_io[i].get_regressed_systime(0, None)
                 # split into smaller iterators
                 sub_iterators = []
                 j = 0
                 previous_multiplex_state = None
                 iterator_loc = len(iterator_size) - i - 1
+                # calculate systime regression on full epoch, parameters stored and inherited by partial iterators
+                self.neo_io[iterator_loc].get_regressed_systime(0, None)
                 while j < size:
                     sub_iterators.append(
                         SpikeGadgetsRawIOPartial(

--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -4,6 +4,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 from pynwb import NWBFile, TimeSeries
+
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -619,10 +619,11 @@ def get_position_timestamps(
 
         frame_count = np.asarray(video_timestamps.HWframeCount)
 
-        is_valid_camera_time = np.isin(video_timestamps.index, sample_count)
-
         epoch_start_ind = np.digitize(epoch_interval[0], rec_dci_timestamps)
         epoch_end_ind = np.digitize(epoch_interval[1], rec_dci_timestamps)
+        is_valid_camera_time = np.isin(
+            video_timestamps.index, sample_count[epoch_start_ind:epoch_end_ind]
+        )
 
         camera_systime = rec_dci_timestamps[
             wrapped_digitize(

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -513,8 +513,8 @@ def get_position_timestamps(
 
     Returns
     -------
-    _type_
-        _description_
+    np.ndarray
+        timestamps for the position data
     """
     logger = logging.getLogger("convert")
 

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -492,6 +492,30 @@ def get_position_timestamps(
     ptp_enabled: bool = True,
     epoch_interval: list[float] | None = None,
 ):
+    """Get the timestamps for a position data file. Includes protocol;s for both ptp and non-ptp data.
+
+    Parameters
+    ----------
+    position_timestamps_filepath : Path
+        path to the position timestamps file
+    position_tracking_filepath : _type_, optional
+        path to the position tracking file, by default None | Path
+    rec_dci_timestamps : _type_, optional
+        system clock times from the rec file used for non-ptp data, by default None | np.ndarray
+    dio_camera_timestamps : _type_, optional
+        Timestamps of the dio camera ticks used for non-ptp data, by default None | np.ndarray
+    sample_count : _type_, optional
+        trodes timestamps from the rec file used for non-ptp data, by default None | np.ndarray
+    ptp_enabled : bool, optional
+        whether ptp was enabled for position tracking, by default True
+    epoch_interval : list[float] | None, optional
+        the timeinterval for the epoch used for non-ptp data, by default None
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
     logger = logging.getLogger("convert")
 
     # Get video timestamps

--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -12,10 +12,10 @@ from ndx_franklab_novela import (
     AssociatedFiles,
     CameraDevice,
     DataAcqDevice,
+    NwbElectrodeGroup,
     Probe,
     Shank,
     ShanksElectrode,
-    NwbElectrodeGroup,
 )
 from pynwb import NWBFile
 from pynwb.file import ProcessingModule, Subject

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 from pynwb import NWBHDF5IO
+
 from trodes_to_nwb.convert import create_nwbs, get_included_probe_metadata_paths
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.utils import data_path

--- a/src/trodes_to_nwb/tests/test_convert_dios.py
+++ b/src/trodes_to_nwb/tests/test_convert_dios.py
@@ -2,11 +2,11 @@ import os
 
 import numpy as np
 import pynwb
+
+from trodes_to_nwb import convert_yaml
 from trodes_to_nwb.convert_dios import add_dios
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
-
-from trodes_to_nwb import convert_yaml
 
 
 def test_add_dios_single_rec():

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 import numpy as np
 import pynwb
+
+from trodes_to_nwb import convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_ephys import add_raw_ephys
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
-
-from trodes_to_nwb import convert_rec_header, convert_yaml
 
 MICROVOLTS_PER_VOLT = 1e6
 

--- a/src/trodes_to_nwb/tests/test_convert_intervals.py
+++ b/src/trodes_to_nwb/tests/test_convert_intervals.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 from pynwb import NWBHDF5IO
+
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 from trodes_to_nwb.convert_intervals import add_epochs, add_sample_count
 from trodes_to_nwb.convert_yaml import initialize_nwb, load_metadata

--- a/src/trodes_to_nwb/tests/test_convert_position.py
+++ b/src/trodes_to_nwb/tests/test_convert_position.py
@@ -5,6 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from pynwb import NWBHDF5IO, TimeSeries
+
+from trodes_to_nwb import convert, convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_dios import add_dios
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 from trodes_to_nwb.convert_intervals import add_epochs, add_sample_count
@@ -26,8 +28,6 @@ from trodes_to_nwb.convert_position import (
 )
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.utils import data_path
-
-from trodes_to_nwb import convert, convert_rec_header, convert_yaml
 
 
 def test_wrapped_digitize():

--- a/src/trodes_to_nwb/tests/test_convert_rec_header.py
+++ b/src/trodes_to_nwb/tests/test_convert_rec_header.py
@@ -3,9 +3,9 @@ from xml.etree import ElementTree
 
 import pytest
 from ndx_franklab_novela import HeaderDevice
-from trodes_to_nwb.tests.utils import data_path
 
 from trodes_to_nwb import convert, convert_rec_header, convert_yaml
+from trodes_to_nwb.tests.utils import data_path
 
 
 def default_test_xml_tree() -> ElementTree:

--- a/src/trodes_to_nwb/tests/test_data/test_metadata_dict_samples.py
+++ b/src/trodes_to_nwb/tests/test_data/test_metadata_dict_samples.py
@@ -1,5 +1,6 @@
-import pytest
 import copy
+
+import pytest
 
 basic_data = {
     "experimenter_name": ["michael jackson"],

--- a/src/trodes_to_nwb/tests/test_metadata_validation.py
+++ b/src/trodes_to_nwb/tests/test_metadata_validation.py
@@ -3,7 +3,6 @@ import datetime
 from unittest.mock import MagicMock, patch
 
 from trodes_to_nwb.metadata_validation import _get_nwb_json_schema_path, validate
-
 from trodes_to_nwb.tests.test_data import test_metadata_dict_samples
 
 

--- a/src/trodes_to_nwb/tests/test_spikegadgets_io.py
+++ b/src/trodes_to_nwb/tests/test_spikegadgets_io.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from trodes_to_nwb.spike_gadgets_raw_io import InsertedMemmap, SpikeGadgetsRawIO
 from trodes_to_nwb.tests.utils import data_path
 

--- a/src/trodes_to_nwb/tests/utils.py
+++ b/src/trodes_to_nwb/tests/utils.py
@@ -1,8 +1,8 @@
 """Set the path to the bulk test data dir and copies the yaml/config files there"""
-import os
-from pathlib import Path
-import shutil
 
+import os
+import shutil
+from pathlib import Path
 
 yaml_path = Path(__file__).resolve().parent / "test_data"
 


### PR DESCRIPTION
Resolves #80 
- When matching trodes timestamps from position tracking and rec file, first restrict the rec trodes timestamps to those corresponding to a rec system clock time within the epoch
- Enables accurate mapping when trodes timestamps are not uniques across epochs, but are unique within the epoch
- Gives minor speed and efficiency improvements
- Added documentation for `get_position_timestamps()`