### PR TITLE
Num hw chan resolution

### DIFF
--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -213,7 +213,9 @@ def _create_nwb(
 
     logger.info("CREATING REC DATA ITERATORS")
     # make generic rec file data chunk iterator to pass to functions
-    rec_dci = RecFileDataChunkIterator(rec_filepaths, interpolate_dropped_packets=False)
+    rec_dci = RecFileDataChunkIterator(
+        rec_filepaths, interpolate_dropped_packets=False, stream_id="trodes"
+    )
     rec_dci_timestamps = (
         rec_dci.timestamps
     )  # pass these when creating other non-interpolated rec iterators to save time

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -87,6 +87,8 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         else:
             self.nwb_hw_channel_order = nwb_hw_channel_order
 
+        if stream_index == 3 and len(self.nwb_hw_channel_order) < self.n_channel:
+            self.n_channel = len(self.nwb_hw_channel_order)
         """split excessively large iterators into smaller ones
         """
         iterator_size = [neo_io._raw_memmap.shape[0] for neo_io in self.neo_io]

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -743,6 +743,12 @@ class SpikeGadgetsRawIO(BaseRawIO):
         print("Interpolate memmap: ", self.filename)
         self._raw_memmap = InsertedMemmap(self._raw_memmap, self.interpolate_index)
 
+    def get_stream_index_from_id(self, stream_id):
+        return np.where(self.header["signal_streams"]["id"] == stream_id)[0][0]
+
+    def get_stream_id_from_index(self, stream_index):
+        return self.header["signal_streams"]["id"][stream_index]
+
 
 class InsertedMemmap:
     """

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -101,6 +101,15 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         self._sampling_rate = float(hconf.attrib["samplingRate"])
         num_ephy_channels = int(hconf.attrib["numChannels"])
+        # check for agreement with number of channels in xml
+        sconf_channels = np.sum([len(x) for x in sconf])
+        if sconf_channels < num_ephy_channels:
+            num_ephy_channels = sconf_channels
+        if sconf_channels > num_ephy_channels:
+            raise ValueError(
+                "SpikeGadgets: the number of channels in the spike configuration is larger than the number of channels in the hardware configuration"
+            )
+
         try:
             num_chan_per_chip = int(sconf.attrib["chanPerChip"])
         except KeyError:

--- a/src/trodes_to_nwb/tests/test_convert_intervals.py
+++ b/src/trodes_to_nwb/tests/test_convert_intervals.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 from pynwb import NWBHDF5IO
+
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 from trodes_to_nwb.convert_intervals import add_epochs, add_sample_count
 from trodes_to_nwb.convert_yaml import initialize_nwb, load_metadata
@@ -21,7 +22,8 @@ def test_add_epochs():
     rec_to_nwb_file = data_path / "minirec20230622_.nwb"  # comparison file
     # get all streams for all files
     rec_dci = RecFileDataChunkIterator(
-        file_info[file_info.file_extension == ".rec"].full_path.to_list()
+        file_info[file_info.file_extension == ".rec"].full_path.to_list(),
+        stream_id="trodes",
     )
     add_epochs(nwbfile, file_info, rec_dci.neo_io)
     epochs_df = nwbfile.epochs.to_dataframe()
@@ -48,7 +50,7 @@ def test_add_sample_count():
     rec_to_nwb_file = data_path / "minirec20230622_.nwb"  # comparison file
 
     # make recfile data chunk iterator
-    rec_dci = RecFileDataChunkIterator(recfile)
+    rec_dci = RecFileDataChunkIterator(recfile, stream_id="trodes")
 
     # add sample counts
     add_sample_count(nwbfile, rec_dci)

--- a/src/trodes_to_nwb/tests/utils.py
+++ b/src/trodes_to_nwb/tests/utils.py
@@ -1,8 +1,8 @@
 """Set the path to the bulk test data dir and copies the yaml/config files there"""
-import os
-from pathlib import Path
-import shutil
 
+import os
+import shutil
+from pathlib import Path
 
 yaml_path = Path(__file__).resolve().parent / "test_data"
 


### PR DESCRIPTION
Resolves #83 
- Checks the number of ephys channels based on the spike config in the rec header in the `SpikeGadgetsRawIO` object

Resolves #84
 - Limits max shape of `RecDataChunkIterator` to the number of ephys channels requested
 - Allows conversion of just a subset of the devices recorded

New features
- Allows selection of stream in `RecFileDataChunkIterator` based on stream name rather than only by index for more intuitive use
- Checks for consistency if both values are provided