### PR TITLE
Fix error in io splitter if no systime

### DIFF
--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -146,7 +146,8 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 previous_multiplex_state = None
                 iterator_loc = len(iterator_size) - i - 1
                 # calculate systime regression on full epoch, parameters stored and inherited by partial iterators
-                self.neo_io[iterator_loc].get_regressed_systime(0, None)
+                if self.neo_io[iterator_loc].sysClock_byte:
+                    self.neo_io[iterator_loc].get_regressed_systime(0, None)          
                 while j < size:
                     sub_iterators.append(
                         SpikeGadgetsRawIOPartial(

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -147,7 +147,7 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 iterator_loc = len(iterator_size) - i - 1
                 # calculate systime regression on full epoch, parameters stored and inherited by partial iterators
                 if self.neo_io[iterator_loc].sysClock_byte:
-                    self.neo_io[iterator_loc].get_regressed_systime(0, None)          
+                    self.neo_io[iterator_loc].get_regressed_systime(0, None)
                 while j < size:
                     sub_iterators.append(
                         SpikeGadgetsRawIOPartial(


### PR DESCRIPTION
Bug existed because the rec iterator splitting for large files assumed `sysClock` was available in the rec file. This fixes that and only calculates overall regression parameters only if the `sysClock` is present