### PR TITLE
Fixes for numpy 2.0

### DIFF
--- a/.github/workflows/test_package_build.yml
+++ b/.github/workflows/test_package_build.yml
@@ -29,14 +29,14 @@ jobs:
         run: python -m build
       - run: twine check dist/*
       - name: Upload sdist and wheel artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
       - name: Build git archive
         run: mkdir archive && git archive -v -o archive/archive.tgz HEAD
       - name: Upload git archive artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: archive
           path: archive/
@@ -51,13 +51,13 @@ jobs:
     steps:
       - name: Download sdist and wheel artifacts
         if: matrix.package != 'archive'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
       - name: Download git archive artifact
         if: matrix.package == 'archive'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: archive
           path: archive/
@@ -117,7 +117,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -94,7 +94,7 @@ def parse_dtype(fieldstr: str) -> np.dtype:
     --------
     >>> fieldstr = '<time uint32><x float32><y float32><z float32>'
     >>> parse_dtype(fieldstr)
-    dtype([('time', '<u4'), ('x', '<f4'), ('y', '<f4'), ('z', '<f4')])
+    dtype([('time', '<u4', (1,)), ('x', '<f4', (1,)), ('y', '<f4', (1,)), ('z', '<f4', (1,))])
 
     """
     # Returns np.dtype from field string

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -560,8 +560,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
         )
         # read the data into int16
         data = (
-            self._raw_memmap[:, data_offsets[:, 0]]
-            + self._raw_memmap[:, data_offsets[:, 0] + 1] * INT_16_CONVERSION
+            self._raw_memmap[:, data_offsets[:, 0]].astype(np.int16)
+            + self._raw_memmap[:, data_offsets[:, 0] + 1].astype(np.int16)
+            * INT_16_CONVERSION
         )
         # initialize the first row
         analog_multiplexed_data[0] = data[0]
@@ -646,8 +647,8 @@ class SpikeGadgetsRawIO(BaseRawIO):
         )
         # read the data into int16
         data = (
-            self._raw_memmap[i_start:i_stop, data_offsets[:, 0]]
-            + self._raw_memmap[i_start:i_stop, data_offsets[:, 0] + 1]
+            self._raw_memmap[i_start:i_stop, data_offsets[:, 0]].astype(np.int16)
+            + self._raw_memmap[i_start:i_stop, data_offsets[:, 0] + 1].astype(np.int16)
             * INT_16_CONVERSION
         )
         # initialize the first row
@@ -969,8 +970,9 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         )
         # read the data into int16
         data = (
-            self._raw_memmap[:, data_offsets[:, 0]]
-            + self._raw_memmap[:, data_offsets[:, 0] + 1] * INT_16_CONVERSION
+            self._raw_memmap[:, data_offsets[:, 0]].astype(np.int16)
+            + self._raw_memmap[:, data_offsets[:, 0] + 1].astype(np.int16)
+            * INT_16_CONVERSION
         )
         # initialize the first row
         # if no previous state, assume first segment. Default to superclass behavior

--- a/src/trodes_to_nwb/tests/test_convert_position.py
+++ b/src/trodes_to_nwb/tests/test_convert_position.py
@@ -12,6 +12,7 @@ from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 from trodes_to_nwb.convert_intervals import add_epochs, add_sample_count
 from trodes_to_nwb.convert_position import (
     add_position,
+    convert_datafile_to_pandas,
     correct_timestamps_for_camera_to_mcu_lag,
     detect_repeat_timestamps,
     detect_trodes_time_repeats_or_frame_jumps,
@@ -79,7 +80,7 @@ def test_read_trodes_datafile_correct_settings(tmp_path):
     result = read_trodes_datafile(filename)
     assert result["clock rate"] == "30000"
 
-    expected_data = pd.DataFrame(result["data"])
+    expected_data = convert_datafile_to_pandas(result)
     assert expected_data["field1"].dtype == np.uint32
     assert expected_data["field2"].dtype == np.int32
     assert np.array_equal(expected_data.field1, np.array([1, 3], dtype=np.uint32))


### PR DESCRIPTION
numpy 2.0 introduced new errors. Required changes:

- columns object returned by `np.fromfile` now have a second axis of one dimesnion
    - [Source of error:](https://github.com/numpy/numpy/pull/25761) 
    > np.dtype(("f8", 1) will now return a shape 1 subarray dtype rather than a non-subarray one. 

    - This raised errors when converting to pandas dataframe
    - Add function `convert_datafile_to_pandas` to  do this cleanly
- Numpy changed promotion rules of datatypes in [2.0  ](https://numpy.org/devdocs/release/2.0.0-notes.html)
    -  memap now required explicit casting to int16 in analog signal processing in `SpikeGadgetsRawIO`