### PR TITLE
Share memmap objects to conserve virtual memory

### DIFF
--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -199,7 +199,7 @@ def _create_nwb(
     session_df: pd.DataFrame,
     header_reconfig_path: Path | None = None,
     probe_metadata_paths: list[Path] | None = None,
-    output_dir: str = "/home/stelmo/nwb/raw",
+    output_dir: str = "/stelmo/nwb/raw",
     video_directory: str = "",
     convert_video: bool = False,
     disable_ptp: bool = False,

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -921,7 +921,7 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
                 ValueError(
                     "SpikeGadgets: the xml header does not contain '</Configuration>'"
                 )
-
+        # Inherit the original memmap object from the full_io object to conserve virtual memory
         if isinstance(full_io._raw_memmap, InsertedMemmap):
             self._raw_memmap = full_io._raw_memmap._raw_memmap
         else:
@@ -988,7 +988,7 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         # initialize the first row
         # if no previous state, assume first segment. Default to superclass behavior
         analog_multiplexed_data[0] = data[0]
-        if not self.previous_multiplex_state is None:
+        if self.previous_multiplex_state is not None:
             # if previous state, use it to initialize elements of first row not updated in that packet
             ind = np.where(initialize_stream_mask[0])[0]
             analog_multiplexed_data[0][ind] = self.previous_multiplex_state[ind]

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -922,11 +922,6 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
                     "SpikeGadgets: the xml header does not contain '</Configuration>'"
                 )
 
-        # raw_memmap = np.memmap(self.filename, mode="r", offset=header_size, dtype="<u1")
-        # packet_size = full_io._raw_memmap.shape[1]
-        # num_packet = raw_memmap.size // packet_size
-        # raw_memmap = raw_memmap[: num_packet * packet_size]
-        # self._raw_memmap = raw_memmap.reshape(-1, packet_size)
         if isinstance(full_io._raw_memmap, InsertedMemmap):
             self._raw_memmap = full_io._raw_memmap._raw_memmap
         else:

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -44,7 +44,7 @@ def test_get_file_info():
 def test_get_included_probe_metadata_paths():
     probes = get_included_probe_metadata_paths()
     assert len(probes) == 9
-    assert [probe.exists() for probe in probes]
+    assert all([probe.exists() for probe in probes])
 
 
 def test_convert_full():

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 from pynwb import NWBHDF5IO
@@ -40,7 +41,7 @@ def test_get_file_info():
         assert Path(file).exists()
 
 
-def test_get_included_probe_metadat_paths():
+def test_get_included_probe_metadata_paths():
     probes = get_included_probe_metadata_paths()
     assert len(probes) == 9
     assert [probe.exists() for probe in probes]
@@ -80,6 +81,11 @@ def test_convert_full():
     os.remove(output_file_path)
     os.remove(output_report_path)
     shutil.rmtree(video_directory)
+
+
+def test_convert_full_partial_iterators():
+    with patch("trodes_to_nwb.convert_ephys.MAXIMUM_ITERATOR_SIZE", new=5000):
+        test_convert_full()
 
 
 def test_convert_full_with_inspector_error(mocker):


### PR DESCRIPTION
- Fixes #109 
    - When instantiating  a `SpikeGadgetsRawIOPartial` object, inherit the `_raw_memmap` object from the original `SpikeGadgetsRawIO` object
    - For long continuous recordings (e.g. overnight) this significantly reduces the virtual memory used by `RecFileDataChunkIterator`
        - only single `np. memmap` object created per epoch rather than one for each partial iterator

- Fixes #106 
    - Update the default ouytput dir to `/stelmo/nwb/raw` 