### PR TITLE
Update for pynwb use of `DeviceModel`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - numpy
 - scipy
 - pandas
-- pynwb<=3.0.0
+- pynwb>=3.1.0
 - nwbinspector>=0.5.0
 - dask
 - ipython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "scipy",
     "pandas",
-    "pynwb<=3.0.0",
+    "pynwb>=3.1.0",
     "nwbinspector>=0.5.0",
     "ndx_franklab_novela",
     "pyyaml",

--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -25,6 +25,12 @@ from ndx_franklab_novela import (
 from pynwb import NWBFile
 from pynwb.file import ProcessingModule, Subject
 
+try:
+    from pynwb.device import DeviceModel
+except ImportError:
+    # Temporary error message to ensure existing users have the correct version of pynwb
+    raise ImportError("Please upgrade pynwb to 3.1.0 or later")
+
 import trodes_to_nwb.metadata_validation
 from trodes_to_nwb import __version__
 
@@ -135,12 +141,17 @@ def add_cameras(nwbfile: NWBFile, metadata: dict) -> None:
     """
     # add each camera device to the nwb
     for camera_metadata in metadata["cameras"]:
+        model = DeviceModel(
+            name=camera_metadata["model"],
+            manufacturer=camera_metadata["manufacturer"],
+            description="",
+        )
         nwbfile.add_device(
             CameraDevice(
                 name="camera_device " + str(camera_metadata["id"]),
                 meters_per_pixel=camera_metadata["meters_per_pixel"],
                 manufacturer=camera_metadata["manufacturer"],
-                model=camera_metadata["model"],
+                model=model,
                 lens=camera_metadata["lens"],
                 camera_name=camera_metadata["camera_name"],
             )


### PR DESCRIPTION
Fixes #124 

- Use `DeviceModel` in `add_ameras`