### PR TITLE
Handle no Reference Electrode

### DIFF
--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -300,6 +300,10 @@ def add_electrode_groups(
     for nwb_group in list(electrode_table["group_name"]):
         # use the refference electrode map and defined electrode table to find index of the reference electrode
         ref_group, ref_electrode = ref_electrode_map[str(nwb_group)]
+        if ref_group == "-1":
+            # handle case where no reference electrode is defined
+            ref_electrode_id.append(-1)
+            continue
         ref_electrode_id.append(
             electrode_table.index[
                 (electrode_table["group_name"] == ref_group)

--- a/src/trodes_to_nwb/tests/test_convert_yaml.py
+++ b/src/trodes_to_nwb/tests/test_convert_yaml.py
@@ -288,6 +288,31 @@ def test_add_tasks():
         assert task_df["task_environment"][0] == task_metadata["task_environment"]
 
 
+def test_no_reference_electrode():
+    metadata_path = data_path / "20230622_sample_metadata.yml"
+    probe_metadata = [data_path / "tetrode_12.5.yml"]
+    metadata, probe_metadata = convert_yaml.load_metadata(metadata_path, probe_metadata)
+    nwbfile = convert_yaml.initialize_nwb(metadata, default_test_xml_tree())
+
+    # create the hw_channel map using rec data
+    recfile = data_path / "20230622_sample_01_a1.rec"
+    rec_header = convert_rec_header.read_header(recfile)
+    hw_channel_map = convert_rec_header.make_hw_channel_map(
+        metadata, rec_header.find("SpikeConfiguration")
+    )
+    ref_electrode_map = convert_rec_header.make_ref_electrode_map(
+        metadata, rec_header.find("SpikeConfiguration")
+    )
+    # set one terode to no reference
+    ref_electrode_map["0"] = ("-1", -1)
+    convert_yaml.add_electrode_groups(
+        nwbfile, metadata, probe_metadata, hw_channel_map, ref_electrode_map
+    )
+    df = nwbfile.electrodes.to_dataframe()
+    assert all(df[df["group_name"] == "0"].ref_elect_id.unique() == -1)
+    assert all(df[df["group_name"] != "0"].ref_elect_id.unique() == 0)
+
+
 def test_add_associated_files(capsys):
     # Create a logger
     logger = convert.setup_logger("convert", "testing.log")


### PR DESCRIPTION
Fixes #126
- in add electrode groups, assign `ref_elect_id = -1` in the electrodes table in cases where the reference was not used
- add test for this case