### PR TITLE
Validate metadata against database

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Developers should install from source.
        `-- README.md
     ```
 
+    _Optional_
+
+    > For those using `spyglass` for data management, you can check your yaml against
+    existing database entries prior to conversion with the following code:
+
+    ```python
+    from trodes_to_nwb.database_validation import yaml_database_validation
+    yaml_database_validation("/path/to/yaml/file")
+    ```
+
 3. Run the code in python. This will create a NWB file for each `.rec` file in the output directory.
 
     ```python

--- a/src/trodes_to_nwb/database_validation.py
+++ b/src/trodes_to_nwb/database_validation.py
@@ -1,0 +1,73 @@
+import yaml
+
+spyglass_error = (
+    "This functional is optional and requires the spyglass package. It is only relevant"
+    + " for those using spyglass for data management and requires spyglass be installed."
+)
+
+
+def check_for_brain_region(data: dict):
+    from spyglass.common import BrainRegion
+
+    missing_regions = []
+    for k, v in data.items():
+        if isinstance(v, dict):
+            missing_regions.extend(check_for_brain_region(v))
+            continue
+        if isinstance(v, list):
+            for item in v:
+                if isinstance(item, dict):
+                    missing_regions.extend(check_for_brain_region(item))
+            continue
+        if "location" in k:
+            key = {"region_name": v}
+            if not (BrainRegion & key):
+                missing_regions.append(v)
+    return list(set(missing_regions))
+
+
+def yaml_database_validation(yaml_path: str):
+    """Validate the YAML file against the database tables to reduce duplication and errors.
+
+    Parameters
+    ----------
+    yaml_path : str
+        Path to the YAML file.
+    """
+
+    yaml_data = yaml.safe_load(open(yaml_path))
+    try:
+        from spyglass.common import CameraDevice, Task
+    except ImportError:
+        raise ImportError(spyglass_error)
+
+    # check entries for tables in the database for consistency with the yaml file
+    yaml_to_table = {
+        "tasks": Task(),
+        "cameras": CameraDevice(),
+    }
+    for yaml_key, table in yaml_to_table.items():
+        if yaml_key not in yaml_data:
+            continue
+        print(f"Checking table `{table.camel_name}` against yaml key `{yaml_key}`")
+        for key in yaml_data[yaml_key]:
+            _primary = {k: v for k, v in key.items() if k in table.primary_key}
+            if not (query := (table & _primary)):
+                continue
+
+            table_entry = query.fetch1()
+            for k, v in key.items():
+                if k not in table_entry:
+                    continue
+                if table_entry[k] != v:
+                    print(
+                        f"\tFor entry {_primary} in table {table.camel_name} \n"
+                        + f"\t\t Mismatch in {k}: {table_entry[k]} != {v}"
+                    )
+    if new_regions := check_for_brain_region(yaml_data):
+        print(
+            "The following brain regions are missing from the BrainRegion table.\n"
+            + " Consider using existing BrainRegion entries:"
+        )
+        for region in new_regions:
+            print(f"\t{region}")

--- a/src/trodes_to_nwb/database_validation.py
+++ b/src/trodes_to_nwb/database_validation.py
@@ -35,7 +35,8 @@ def yaml_database_validation(yaml_path: str):
         Path to the YAML file.
     """
 
-    yaml_data = yaml.safe_load(open(yaml_path))
+    with open(yaml_path) as f:
+        yaml_data = yaml.safe_load(f)
     try:
         from spyglass.common import CameraDevice, Task
     except ImportError:


### PR DESCRIPTION
This pull request adds an optional YAML validation utility for users of the `spyglass` data management system. The new feature allows users to validate their YAML files against existing database entries to help reduce duplication and errors. Documentation has also been updated to describe this new functionality.

**New YAML validation for spyglass users:**

* Added a new function `yaml_database_validation` in `database_validation.py` that checks a YAML file against the `CameraDevice`, `Task`, and `BrainRegion` tables in the spyglass database, reporting mismatches and missing regions.
* Implemented a helper function `check_for_brain_region` to identify brain regions in the YAML that are missing from the database.

**Documentation update:**

* Updated the `README.md` to include instructions for using the new YAML validation feature, emphasizing that it is optional and only relevant for spyglass users.