### PR TITLE
Correctly store `sample_counts` timestamps as seconds

### DIFF
--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -91,7 +91,7 @@ def add_sample_count(
     )
 
     # get the systime information
-    systime = np.array(rec_dci.timestamps) * NANOSECONDS_PER_SECOND
+    systime = np.array(rec_dci.timestamps)
     # get the sample count information
     trodes_sample = np.concatenate(
         [neo_io.get_analogsignal_timestamps(0, None) for neo_io in rec_dci.neo_io]

--- a/src/trodes_to_nwb/tests/test_convert_intervals.py
+++ b/src/trodes_to_nwb/tests/test_convert_intervals.py
@@ -10,6 +10,8 @@ from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
 
+NANOSECONDS_PER_SECOND = 1e9
+
 
 def test_add_epochs():
     metadata_path = data_path / "20230622_sample_metadata.yml"
@@ -69,7 +71,8 @@ def test_add_sample_count():
                 == old_nwbfile.processing["sample_count"]["sample_count"].data[:]
             ).all()
             assert np.allclose(
-                read_nwbfile.processing["sample_count"]["sample_count"].timestamps[:],
+                read_nwbfile.processing["sample_count"]["sample_count"].timestamps[:]
+                * NANOSECONDS_PER_SECOND,  # Account for error in old file timestamps
                 old_nwbfile.processing["sample_count"]["sample_count"].timestamps[:],
                 rtol=0,
                 atol=(1.0 / 30000) * 1e9,


### PR DESCRIPTION
- Error identified where the timesteps in `sample_counts` was innapropriately scaled to nanoseconds, even though units required to be seconds
- Correctly stores as seconds and adjusts test