### PR TITLE
Rec timing checks

### DIFF
--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -139,7 +139,7 @@ def check_file_timing(filepaths: list[str]):
                 f"Files are out of order: \n"
                 + f"File {io._raw_memmap.filename} has start time "
                 + f"({datetime.fromtimestamp(st_time)})"
-                + f" that is before or equal to the the start time of"
+                + f" that is before or equal to the start time of"
                 + f" {io_list[i-1]._raw_memmap.filename} "
                 + f"({datetime.fromtimestamp(start_times[-1])})"
             )

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -130,17 +130,17 @@ def check_file_timing(filepaths: list[str]):
         en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
         if en_time - st_time < 0:
             raise ValueError(
-                f"File {io._raw_memap.filename} has inconsistent timing: \n"
+                f"File {io._raw_memmap.filename} has inconsistent timing: \n"
                 + f"start time ({datetime.fromtimestamp(st_time)}) is after "
                 + f"end time ({datetime.fromtimestamp(en_time)})"
             )
         if len(start_times) > 0 and st_time <= start_times[-1]:
             raise ValueError(
                 f"Files are out of order: \n"
-                + f"File {io._raw_memap.filename} has start time "
+                + f"File {io._raw_memmap.filename} has start time "
                 + f"({datetime.fromtimestamp(st_time)})"
                 + f" that is before or equal to the the start time of"
-                + f" {io_list[i-1]._raw_memap.filename} "
+                + f" {io_list[i-1]._raw_memmap.filename} "
                 + f"({datetime.fromtimestamp(start_times[-1])})"
             )
         start_times.append(st_time)

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -126,7 +126,7 @@ def check_file_timing(filepaths: list[str]):
         io_list.append(io)
     start_times = []
     for i, io in enumerate(io_list):
-        st_time = io.get_sys_clock(0, 1)[0] / 1
+        st_time = io.get_sys_clock(0, 1)[0] / 1e9
         en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
         if en_time - st_time < 0:
             raise ValueError(

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -12,6 +12,7 @@ import nwbinspector
 import pandas as pd
 from dask.distributed import Client
 from pynwb import NWBHDF5IO
+from datetime import datetime
 
 from trodes_to_nwb.convert_analog import add_analog_data
 from trodes_to_nwb.convert_dios import add_dios
@@ -38,6 +39,7 @@ from trodes_to_nwb.convert_yaml import (
     load_metadata,
 )
 from trodes_to_nwb.data_scanner import get_file_info
+from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 
 
 def setup_logger(name_logfile: str, path_logfile: str) -> logging.Logger:
@@ -100,6 +102,48 @@ def _get_file_paths(df: pd.DataFrame, file_extension: str) -> list[str]:
         File paths for the given file extension
     """
     return df.loc[df.file_extension == file_extension].full_path.to_list()
+
+
+def check_file_timing(filepaths: list[str]):
+    """Check that the timing of the given files is consistent
+
+    Parameters
+    ----------
+    filepaths : list[str]
+        List of file paths to check
+
+    Raises
+    ------
+    ValueError
+        If the timing of the files is not consistent
+    """
+    io_list = []
+    for file in filepaths:
+        io = SpikeGadgetsRawIO(
+            file,
+        )
+        io.parse_header()
+        io_list.append(io)
+    start_times = []
+    for i, io in enumerate(io_list):
+        st_time = io.get_sys_clock(0, 1)[0] / 1
+        en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
+        if en_time - st_time < 0:
+            raise ValueError(
+                f"File {io._raw_memap.filename} has inconsistent timing: \n"
+                + f"start time ({datetime.fromtimestamp(st_time)}) is after "
+                + f"end time ({datetime.fromtimestamp(en_time)})"
+            )
+        if len(start_times) > 0 and st_time <= start_times[-1]:
+            raise ValueError(
+                f"Files are out of order: \n"
+                + f"File {io._raw_memap.filename} has start time "
+                + f"({datetime.fromtimestamp(st_time)})"
+                + f" that is before or equal to the the start time of"
+                + f" {io_list[i-1]._raw_memap.filename} "
+                + f"({datetime.fromtimestamp(start_times[-1])})"
+            )
+        start_times.append(st_time)
 
 
 def create_nwbs(
@@ -227,6 +271,7 @@ def _create_nwb(
     logger.info(f"Creating NWB file for session: {session}")
     rec_filepaths = _get_file_paths(session_df, ".rec")
     logger.info(f"\trec_filepaths: {rec_filepaths}")
+    check_file_timing(rec_filepaths)
 
     logger.info("CREATING REC DATA ITERATORS")
     # make generic rec file data chunk iterator to pass to functions

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -130,7 +130,7 @@ def check_file_timing(filepaths: list[str]):
         st_time = (
             io.get_sys_clock(0, 1)[0] / 1e9
             if sys_clock
-            else io.system_time_at_creation / 1e3
+            else float(io.system_time_at_creation) / 1e3
         )
         if len(start_times) > 0 and st_time <= start_times[-1]:
             raise ValueError(

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -41,6 +41,9 @@ from trodes_to_nwb.convert_yaml import (
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 
+NANOSECONDS_PER_SECOND = 1e9
+MILLISECONDS_PER_SECOND = 1e3
+
 
 def setup_logger(name_logfile: str, path_logfile: str) -> logging.Logger:
     """Sets up a logger for each function that outputs
@@ -138,9 +141,9 @@ def check_file_timing(filepaths: list[str], logger: logging.Logger):
     start_times = []
     for i, io in enumerate(io_list):
         st_time = (
-            io.get_sys_clock(0, 1)[0] / 1e9
+            io.get_sys_clock(0, 1)[0] / NANOSECONDS_PER_SECOND
             if sys_clock
-            else float(io.system_time_at_creation) / 1e3
+            else float(io.system_time_at_creation) / MILLISECONDS_PER_SECOND
         )
         if len(start_times) > 0 and st_time <= start_times[-1]:
             relation = "equal to" if st_time == start_times[-1] else "before"
@@ -158,7 +161,10 @@ def check_file_timing(filepaths: list[str], logger: logging.Logger):
                 f"File {io._raw_memmap.filename} does not have sysClock_byte set in header."
             )
             continue
-        en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
+        en_time = (
+            io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0]
+            / NANOSECONDS_PER_SECOND
+        )
         if en_time - st_time < 0:
             raise ValueError(
                 f"File {io._raw_memmap.filename} has inconsistent timing: \n"

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -117,6 +117,8 @@ def check_file_timing(filepaths: list[str]):
     ValueError
         If the timing of the files is not consistent
     """
+    if len(filepaths) == 0:
+        return
     io_list = []
     for file in filepaths:
         io = SpikeGadgetsRawIO(

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -124,16 +124,14 @@ def check_file_timing(filepaths: list[str]):
         )
         io.parse_header()
         io_list.append(io)
+    sys_clock = bool(io_list[0].sysClock_byte)
     start_times = []
     for i, io in enumerate(io_list):
-        st_time = io.get_sys_clock(0, 1)[0] / 1e9
-        en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
-        if en_time - st_time < 0:
-            raise ValueError(
-                f"File {io._raw_memmap.filename} has inconsistent timing: \n"
-                + f"start time ({datetime.fromtimestamp(st_time)}) is after "
-                + f"end time ({datetime.fromtimestamp(en_time)})"
-            )
+        st_time = (
+            io.get_sys_clock(0, 1)[0] / 1e9
+            if sys_clock
+            else io.system_time_at_creation / 1e3
+        )
         if len(start_times) > 0 and st_time <= start_times[-1]:
             raise ValueError(
                 f"Files are out of order: \n"
@@ -144,6 +142,15 @@ def check_file_timing(filepaths: list[str]):
                 + f"({datetime.fromtimestamp(start_times[-1])})"
             )
         start_times.append(st_time)
+        if not sys_clock:
+            continue
+        en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
+        if en_time - st_time < 0:
+            raise ValueError(
+                f"File {io._raw_memmap.filename} has inconsistent timing: \n"
+                + f"start time ({datetime.fromtimestamp(st_time)}) is after "
+                + f"end time ({datetime.fromtimestamp(en_time)})"
+            )
 
 
 def create_nwbs(

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -139,6 +139,7 @@ def check_file_timing(filepaths: list[str], logger: logging.Logger):
         )
     sys_clock = sys_clock[0]  # all values are the same so just take the first one
     start_times = []
+    end_times = []
     for i, io in enumerate(io_list):
         st_time = (
             io.get_sys_clock(0, 1)[0] / NANOSECONDS_PER_SECOND
@@ -155,6 +156,15 @@ def check_file_timing(filepaths: list[str], logger: logging.Logger):
                 + f" {io_list[i-1]._raw_memmap.filename} "
                 + f"({datetime.fromtimestamp(start_times[-1])})"
             )
+        if len(end_times) > 0 and st_time < end_times[-1]:
+            raise ValueError(
+                "File times overlap: \n"
+                + f"File {io._raw_memmap.filename} has start time "
+                + f"({datetime.fromtimestamp(st_time)}) that is before the end time of "
+                + f"{io_list[i-1]._raw_memmap.filename} "
+                + f"({datetime.fromtimestamp(end_times[-1])})"
+            )
+
         start_times.append(st_time)
         if not sys_clock:
             logger.warning(
@@ -171,6 +181,7 @@ def check_file_timing(filepaths: list[str], logger: logging.Logger):
                 + f"start time ({datetime.fromtimestamp(st_time)}) is after "
                 + f"end time ({datetime.fromtimestamp(en_time)})"
             )
+        end_times.append(en_time)
 
 
 def create_nwbs(

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -104,18 +104,20 @@ def _get_file_paths(df: pd.DataFrame, file_extension: str) -> list[str]:
     return df.loc[df.file_extension == file_extension].full_path.to_list()
 
 
-def check_file_timing(filepaths: list[str]):
+def check_file_timing(filepaths: list[str], logger: logging.Logger):
     """Check that the timing of the given files is consistent
 
     Parameters
     ----------
     filepaths : list[str]
         List of file paths to check
+    logger : logging.Logger
+        Logger object to log warnings and errors
 
     Raises
     ------
     ValueError
-        If the timing of the files is not consistent
+        If the timing of the files is not consistent or if files cannot be correctly parsed
     """
     if len(filepaths) == 0:
         return
@@ -126,7 +128,13 @@ def check_file_timing(filepaths: list[str]):
         )
         io.parse_header()
         io_list.append(io)
-    sys_clock = bool(io_list[0].sysClock_byte)
+    sys_clock = [bool(io.sysClock_byte) for io in io_list]
+    if not all(sys_clock) and any(sys_clock):
+        raise ValueError(
+            "Some files have sysClock_byte set in header and some do not. "
+            + "Cannot determine timing consistency."
+        )
+    sys_clock = sys_clock[0]  # all values are the same so just take the first one
     start_times = []
     for i, io in enumerate(io_list):
         st_time = (
@@ -135,16 +143,20 @@ def check_file_timing(filepaths: list[str]):
             else float(io.system_time_at_creation) / 1e3
         )
         if len(start_times) > 0 and st_time <= start_times[-1]:
+            relation = "equal to" if st_time == start_times[-1] else "before"
             raise ValueError(
                 f"Files are out of order: \n"
                 + f"File {io._raw_memmap.filename} has start time "
                 + f"({datetime.fromtimestamp(st_time)})"
-                + f" that is before or equal to the start time of"
+                + f" that is {relation} the start time of"
                 + f" {io_list[i-1]._raw_memmap.filename} "
                 + f"({datetime.fromtimestamp(start_times[-1])})"
             )
         start_times.append(st_time)
         if not sys_clock:
+            logger.warning(
+                f"File {io._raw_memmap.filename} does not have sysClock_byte set in header."
+            )
             continue
         en_time = io.get_sys_clock(io._raw_memmap.shape[0] - 1, None)[0] / 1e9
         if en_time - st_time < 0:
@@ -280,7 +292,7 @@ def _create_nwb(
     logger.info(f"Creating NWB file for session: {session}")
     rec_filepaths = _get_file_paths(session_df, ".rec")
     logger.info(f"\trec_filepaths: {rec_filepaths}")
-    check_file_timing(rec_filepaths)
+    check_file_timing(rec_filepaths, logger)
 
     logger.info("CREATING REC DATA ITERATORS")
     # make generic rec file data chunk iterator to pass to functions

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -337,7 +337,7 @@ def test_check_file_timing_valid_multiple_files_no_sys_clock():
         base_ns, base_ns + int(60 * 1e9), "file1.rec", sys_clock=False
     )
     mock_io2 = _make_mock_io(
-        base_ns + int(120 * 1e9), base_ns + int(180 * 1e9), "file2.rec"
+        base_ns + int(120 * 1e9), base_ns + int(180 * 1e9), "file2.rec", sys_clock=False
     )
 
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -298,7 +298,7 @@ def _make_mock_io(start_ns, end_ns, filename="file.rec"):
         [start_ns] if end == 1 else [end_ns]
     )
     mock_io._raw_memmap.shape = (100, 1)
-    mock_io._raw_memap.filename = filename
+    mock_io._raw_memmap.filename = filename
     return mock_io
 
 

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -12,6 +12,7 @@ from trodes_to_nwb.convert import (
     check_file_timing,
     create_nwbs,
     get_included_device_metadata_paths,
+    setup_logger,
 )
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.utils import data_path
@@ -313,7 +314,7 @@ def test_check_file_timing_valid_single_file():
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.return_value = mock_io
         # Should not raise
-        check_file_timing(["file.rec"])
+        check_file_timing(["file.rec"], setup_logger("test", "test.log"))
 
 
 def test_check_file_timing_valid_multiple_files():
@@ -327,7 +328,7 @@ def test_check_file_timing_valid_multiple_files():
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.side_effect = [mock_io1, mock_io2]
         # Should not raise
-        check_file_timing(["file1.rec", "file2.rec"])
+        check_file_timing(["file1.rec", "file2.rec"], setup_logger("test", "test.log"))
 
 
 def test_check_file_timing_valid_multiple_files_no_sys_clock():
@@ -343,7 +344,7 @@ def test_check_file_timing_valid_multiple_files_no_sys_clock():
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.side_effect = [mock_io1, mock_io2]
         # Should not raise
-        check_file_timing(["file1.rec", "file2.rec"])
+        check_file_timing(["file1.rec", "file2.rec"], setup_logger("test", "test.log"))
 
 
 def test_check_file_timing_negative_duration_raises():
@@ -355,7 +356,7 @@ def test_check_file_timing_negative_duration_raises():
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.return_value = mock_io
         try:
-            check_file_timing(["file.rec"])
+            check_file_timing(["file.rec"], logger=setup_logger("test", "test.log"))
             assert False, "Expected ValueError for negative duration"
         except ValueError:
             pass
@@ -373,7 +374,9 @@ def test_check_file_timing_out_of_order_raises():
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.side_effect = [mock_io1, mock_io2]
         try:
-            check_file_timing(["file1.rec", "file2.rec"])
+            check_file_timing(
+                ["file1.rec", "file2.rec"], logger=setup_logger("test", "test.log")
+            )
             assert False, "Expected ValueError for out of order files"
         except ValueError:
             pass
@@ -388,7 +391,9 @@ def test_check_file_timing_equal_start_times_raises():
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.side_effect = [mock_io1, mock_io2]
         try:
-            check_file_timing(["file1.rec", "file2.rec"])
+            check_file_timing(
+                ["file1.rec", "file2.rec"], logger=setup_logger("test", "test.log")
+            )
             assert False, "Expected ValueError for equal start times"
         except ValueError:
             pass
@@ -396,7 +401,7 @@ def test_check_file_timing_equal_start_times_raises():
 
 def test_check_file_timing_empty_list():
     """check_file_timing should not raise for an empty list."""
-    check_file_timing([])
+    check_file_timing([], logger=setup_logger("test", "test.log"))
 
 
 def test_check_file_timing_parses_header():
@@ -406,5 +411,5 @@ def test_check_file_timing_parses_header():
 
     with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
         MockRawIO.return_value = mock_io
-        check_file_timing(["file.rec"])
+        check_file_timing(["file.rec"], logger=setup_logger("test", "test.log"))
         mock_io.parse_header.assert_called_once()

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -6,7 +6,13 @@ from unittest.mock import patch
 import numpy as np
 from pynwb import NWBHDF5IO
 
-from trodes_to_nwb.convert import create_nwbs, get_included_device_metadata_paths
+from unittest.mock import MagicMock
+
+from trodes_to_nwb.convert import (
+    check_file_timing,
+    create_nwbs,
+    get_included_device_metadata_paths,
+)
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.utils import data_path
 
@@ -283,3 +289,104 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
                 validated = True
                 break
         assert validated, f"Could not find matching series for {series}"
+
+
+def _make_mock_io(start_ns, end_ns, filename="file.rec"):
+    """Helper to create a mock SpikeGadgetsRawIO-like object."""
+    mock_io = MagicMock()
+    mock_io.get_sys_clock.side_effect = lambda start, end: (
+        [start_ns] if end == 1 else [end_ns]
+    )
+    mock_io._raw_memmap.shape = (100, 1)
+    mock_io._raw_memap.filename = filename
+    return mock_io
+
+
+def test_check_file_timing_valid_single_file():
+    """check_file_timing should not raise for a single valid file."""
+    start_ns = int(1e18)  # ~31 years in nanoseconds, valid Unix time in seconds
+    end_ns = start_ns + int(60 * 1e9)  # 60 seconds later
+    mock_io = _make_mock_io(start_ns, end_ns)
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.return_value = mock_io
+        # Should not raise
+        check_file_timing(["file.rec"])
+
+
+def test_check_file_timing_valid_multiple_files():
+    """check_file_timing should not raise for multiple ordered valid files."""
+    base_ns = int(1e18)
+    mock_io1 = _make_mock_io(base_ns, base_ns + int(60 * 1e9), "file1.rec")
+    mock_io2 = _make_mock_io(
+        base_ns + int(120 * 1e9), base_ns + int(180 * 1e9), "file2.rec"
+    )
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.side_effect = [mock_io1, mock_io2]
+        # Should not raise
+        check_file_timing(["file1.rec", "file2.rec"])
+
+
+def test_check_file_timing_negative_duration_raises():
+    """check_file_timing should raise ValueError when end time is before start time."""
+    start_ns = int(1e18)
+    end_ns = start_ns - int(10 * 1e9)  # end before start
+    mock_io = _make_mock_io(start_ns, end_ns)
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.return_value = mock_io
+        try:
+            check_file_timing(["file.rec"])
+            assert False, "Expected ValueError for negative duration"
+        except ValueError:
+            pass
+
+
+def test_check_file_timing_out_of_order_raises():
+    """check_file_timing should raise ValueError when files are out of order."""
+    base_ns = int(1e18)
+    # file2 starts before file1 ends and before file1 starts
+    mock_io1 = _make_mock_io(
+        base_ns + int(120 * 1e9), base_ns + int(180 * 1e9), "file1.rec"
+    )
+    mock_io2 = _make_mock_io(base_ns, base_ns + int(60 * 1e9), "file2.rec")
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.side_effect = [mock_io1, mock_io2]
+        try:
+            check_file_timing(["file1.rec", "file2.rec"])
+            assert False, "Expected ValueError for out of order files"
+        except ValueError:
+            pass
+
+
+def test_check_file_timing_equal_start_times_raises():
+    """check_file_timing should raise ValueError when two files have the same start time."""
+    base_ns = int(1e18)
+    mock_io1 = _make_mock_io(base_ns, base_ns + int(60 * 1e9), "file1.rec")
+    mock_io2 = _make_mock_io(base_ns, base_ns + int(120 * 1e9), "file2.rec")
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.side_effect = [mock_io1, mock_io2]
+        try:
+            check_file_timing(["file1.rec", "file2.rec"])
+            assert False, "Expected ValueError for equal start times"
+        except ValueError:
+            pass
+
+
+def test_check_file_timing_empty_list():
+    """check_file_timing should not raise for an empty list."""
+    check_file_timing([])
+
+
+def test_check_file_timing_parses_header():
+    """check_file_timing should call parse_header for each file."""
+    base_ns = int(1e18)
+    mock_io = _make_mock_io(base_ns, base_ns + int(60 * 1e9))
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.return_value = mock_io
+        check_file_timing(["file.rec"])
+        mock_io.parse_header.assert_called_once()

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -291,7 +291,7 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
         assert validated, f"Could not find matching series for {series}"
 
 
-def _make_mock_io(start_ns, end_ns, filename="file.rec"):
+def _make_mock_io(start_ns, end_ns, filename="file.rec", sys_clock=True):
     """Helper to create a mock SpikeGadgetsRawIO-like object."""
     mock_io = MagicMock()
     mock_io.get_sys_clock.side_effect = lambda start, end: (
@@ -299,6 +299,8 @@ def _make_mock_io(start_ns, end_ns, filename="file.rec"):
     )
     mock_io._raw_memmap.shape = (100, 1)
     mock_io._raw_memmap.filename = filename
+    mock_io.sysClock_byte = sys_clock
+    mock_io.system_time_at_creation = start_ns / 1e6  # in milliseconds
     return mock_io
 
 
@@ -318,6 +320,22 @@ def test_check_file_timing_valid_multiple_files():
     """check_file_timing should not raise for multiple ordered valid files."""
     base_ns = int(1e18)
     mock_io1 = _make_mock_io(base_ns, base_ns + int(60 * 1e9), "file1.rec")
+    mock_io2 = _make_mock_io(
+        base_ns + int(120 * 1e9), base_ns + int(180 * 1e9), "file2.rec"
+    )
+
+    with patch("trodes_to_nwb.convert.SpikeGadgetsRawIO") as MockRawIO:
+        MockRawIO.side_effect = [mock_io1, mock_io2]
+        # Should not raise
+        check_file_timing(["file1.rec", "file2.rec"])
+
+
+def test_check_file_timing_valid_multiple_files_no_sys_clock():
+    """check_file_timing should not raise for multiple ordered valid files."""
+    base_ns = int(1e18)
+    mock_io1 = _make_mock_io(
+        base_ns, base_ns + int(60 * 1e9), "file1.rec", sys_clock=False
+    )
     mock_io2 = _make_mock_io(
         base_ns + int(120 * 1e9), base_ns + int(180 * 1e9), "file2.rec"
     )


### PR DESCRIPTION
Motivated by late-caught errors in converted nwb files based on corrupted or misnamed rec files (#162, #163)

This pull request adds a new function to check the timing consistency of `.rec` files before processing, and introduces comprehensive unit tests to ensure its correctness. The main goal is to catch and report issues with file timing, such as negative durations or out-of-order files, early in the NWB conversion pipeline.

**Timing consistency checking:**

* Added a new function `check_file_timing` in `convert.py` that validates the timing of `.rec` files using `SpikeGadgetsRawIO`. It raises a `ValueError` if a file has a negative duration, files are out of order, or files have equal start times. (`src/trodes_to_nwb/convert.py`)
* Integrated `check_file_timing` into the NWB creation workflow by calling it before processing `.rec` files in `_create_nwb`. (`src/trodes_to_nwb/convert.py`)
* Added the necessary import for `SpikeGadgetsRawIO` and `datetime` to support the new timing check. (`src/trodes_to_nwb/convert.py`) [[1]](diffhunk://#diff-46f9d04ab92c3deddaed6b9f5892c649fe787af847761f2c4d3c95468caffc6eR15) [[2]](diffhunk://#diff-46f9d04ab92c3deddaed6b9f5892c649fe787af847761f2c4d3c95468caffc6eR42)

**Testing:**

* Added a suite of unit tests for `check_file_timing` in `test_convert.py`, covering valid cases, negative durations, out-of-order files, equal start times, empty lists, and header parsing. These tests use mocking to simulate file IO behavior. (`src/trodes_to_nwb/tests/test_convert.py`)
* Updated imports in `test_convert.py` to include `check_file_timing` and necessary test utilities. (`src/trodes_to_nwb/tests/test_convert.py`)