### PR TITLE
Store headstage sensors and ECU analog as separate scaled acquisition TimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 ### Analog / headstage sensors
 
-- **Breaking:** analog data is now written as separate, physically-united
-  `TimeSeries` in `nwbfile.acquisition` (one per sensor type:
+- **Breaking:** analog data is now written as separate `TimeSeries` carrying
+  physical units in `nwbfile.acquisition` (one per sensor type:
   `accelerometer`, `gyroscope`, `magnetometer`, `analog_input`, and `other`
   for unrecognized channels), replacing the single combined
   `processing["analog"]["analog"]["analog"]` stream. Headstage accelerometer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,25 +12,40 @@
 
 - **Breaking:** analog data is now written as separate `TimeSeries` carrying
   physical units in `nwbfile.acquisition` (one per sensor type:
-  `accelerometer`, `gyroscope`, `magnetometer`, `analog_input`, and `other`
-  for unrecognized channels), replacing the single combined
+  `accelerometer`, `gyroscope`, `magnetometer`, `analog_input`, `analog_output`,
+  and `other` for unrecognized channels), replacing the single combined
   `processing["analog"]["analog"]["analog"]` stream. Headstage accelerometer
   and gyroscope data now carry physical units in SI (`m/s^2`, `rad/s`, the NWB
   convention) via each `TimeSeries.conversion` factor; the native sensor scale
   (±2 g, ±2000 deg/s) is noted in each stream's description. Stored values are
   raw int16 and `ts.data[:]` returns raw counts — multiply by `ts.conversion`
-  to get the SI value. Magnetometer, ECU `analog_input`, and `other` streams have
-  no calibrated conversion and remain `unit="unspecified"` (raw counts,
-  conversion 1.0).
+  to get the SI value. Magnetometer, ECU `analog_input`/`analog_output`, and
+  `other` streams have no calibrated conversion and remain `unit="unspecified"`
+  (raw counts, conversion 1.0).
   Optional `sensor_units` metadata can override a sensor's unit *label*. #19
+- Headstage IMU channel names are matched with or without the `Headstage_`
+  prefix, so both modern (`Headstage_AccelX`) and bare Trodes (`AccelX`,
+  `GyroX`, `MagX`) channel ids categorize correctly. ECU analog *output*
+  channels (`ECU_Aout*`) are recognized as `analog_output` instead of being
+  warned as `other`.
 - **Headstage IMU stored at its true rate.** The multiplexed IMU sensors are
   transmitted at the sensor's native rate (~100 Hz) and expanded to the
   acquisition rate by sample-and-hold in the `.rec` stream. They are now
   decimated back to their true rate using the per-packet update flags and
-  stored with explicit `timestamps` (accelerometer and gyroscope are sampled on
-  interleaved schedules, so each carries its own timestamps). A sensor that
+  stored with explicit `timestamps`. Each sensor's channels are partitioned by
+  their per-channel update schedule (`interleavedDataIDByte`/`Bit`): co-sampled
+  channels share one timestamp vector (the common case — one stream per sensor),
+  and channels that update on different schedules are written as separate
+  streams rather than assuming one sensor equals one schedule. A sensor that
   never updates (disabled) is omitted with a warning. ECU analog inputs, which
   are genuinely continuous, remain at the full acquisition rate and lazy/chunked.
+- Reading the continuous ECU analog streams no longer materializes the
+  whole-file sample-and-held multiplexed array (a memory regression): the ECU
+  acquisition path reads only the physical ECU columns, gated by a new
+  `include_multiplexed` flag on `RecFileDataChunkIterator` (the legacy combined
+  layout used by `update_analog_data` keeps `include_multiplexed=True`).
+- Recordings with no ECU device (headstage-only) are supported: only the
+  multiplexed sensor streams are written, with no ECU iterator constructed.
 
   Migration: code that read `nwbfile.processing["analog"]["analog"]["analog"]`
   must instead read the relevant `nwbfile.acquisition[...]` stream. Note IMU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@
   `accelerometer`, `gyroscope`, `magnetometer`, `analog_input`, and `other`
   for unrecognized channels), replacing the single combined
   `processing["analog"]["analog"]["analog"]` stream. Headstage accelerometer
-  and gyroscope data now carry correct physical units (`g`, `d/s`) via each
-  `TimeSeries.conversion` factor. Stored values are raw int16 and `ts.data[:]`
-  returns raw counts — multiply by `ts.conversion` to get physical units.
+  and gyroscope data now carry physical units in SI (`m/s^2`, `rad/s`, the NWB
+  convention) via each `TimeSeries.conversion` factor; the native sensor scale
+  (±2 g, ±2000 deg/s) is noted in each stream's description. Stored values are
+  raw int16 and `ts.data[:]` returns raw counts — multiply by `ts.conversion`
+  to get the SI value.
   Optional `sensor_units` metadata can override a sensor's unit *label*. #19
 - **Headstage IMU stored at its true rate.** The multiplexed IMU sensors are
   transmitted at the sensor's native rate (~100 Hz) and expanded to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
   convention) via each `TimeSeries.conversion` factor; the native sensor scale
   (±2 g, ±2000 deg/s) is noted in each stream's description. Stored values are
   raw int16 and `ts.data[:]` returns raw counts — multiply by `ts.conversion`
-  to get the SI value.
+  to get the SI value. Magnetometer, ECU `analog_input`, and `other` streams have
+  no calibrated conversion and remain `unit="unspecified"` (raw counts,
+  conversion 1.0).
   Optional `sensor_units` metadata can override a sensor's unit *label*. #19
 - **Headstage IMU stored at its true rate.** The multiplexed IMU sensors are
   transmitted at the sensor's native rate (~100 Hz) and expanded to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@
 
 - Update conversions for use of `pynwb>=3.1` #153, #155
 
+### Analog / headstage sensors
+
+- **Breaking:** analog data is now written as separate, physically-united
+  `TimeSeries` in `nwbfile.acquisition` (one per sensor type:
+  `accelerometer`, `gyroscope`, `magnetometer`, `analog_input`, and `other`
+  for unrecognized channels), replacing the single combined
+  `processing["analog"]["analog"]["analog"]` stream. Headstage accelerometer
+  and gyroscope data now carry correct physical units (`g`, `d/s`) via each
+  `TimeSeries.conversion` factor. Data remains lazy/chunked; stored values are
+  raw int16 and `ts.data[:]` returns raw counts — multiply by `ts.conversion`
+  (or read through a conversion-aware API) to get physical units. Optional
+  `sensor_units` metadata can override a sensor's unit *label*. #19
+
+  Migration: code that read `nwbfile.processing["analog"]["analog"]["analog"]`
+  must instead read the relevant `nwbfile.acquisition[...]` stream. Existing
+  files in the old layout can still be repaired with `update_analog_data`.
+
 ### Optogenetics
 
 - fix hfpy write error when different number of spatial node regions between epochs #135

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,22 @@
   for unrecognized channels), replacing the single combined
   `processing["analog"]["analog"]["analog"]` stream. Headstage accelerometer
   and gyroscope data now carry correct physical units (`g`, `d/s`) via each
-  `TimeSeries.conversion` factor. Data remains lazy/chunked; stored values are
-  raw int16 and `ts.data[:]` returns raw counts — multiply by `ts.conversion`
-  (or read through a conversion-aware API) to get physical units. Optional
-  `sensor_units` metadata can override a sensor's unit *label*. #19
+  `TimeSeries.conversion` factor. Stored values are raw int16 and `ts.data[:]`
+  returns raw counts — multiply by `ts.conversion` to get physical units.
+  Optional `sensor_units` metadata can override a sensor's unit *label*. #19
+- **Headstage IMU stored at its true rate.** The multiplexed IMU sensors are
+  transmitted at the sensor's native rate (~100 Hz) and expanded to the
+  acquisition rate by sample-and-hold in the `.rec` stream. They are now
+  decimated back to their true rate using the per-packet update flags and
+  stored with explicit `timestamps` (accelerometer and gyroscope are sampled on
+  interleaved schedules, so each carries its own timestamps). A sensor that
+  never updates (disabled) is omitted with a warning. ECU analog inputs, which
+  are genuinely continuous, remain at the full acquisition rate and lazy/chunked.
 
   Migration: code that read `nwbfile.processing["analog"]["analog"]["analog"]`
-  must instead read the relevant `nwbfile.acquisition[...]` stream. Existing
-  files in the old layout can still be repaired with `update_analog_data`.
+  must instead read the relevant `nwbfile.acquisition[...]` stream. Note IMU
+  streams are now ~100 Hz with their own `timestamps`, not the acquisition rate.
+  Existing files in the old layout can still be repaired with `update_analog_data`.
 
 ### Optogenetics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Required files per session:
 
 ## Important Notes
 
-- Package supports Python >=3.8
+- Package supports Python >=3.10 (per `requires-python` in `pyproject.toml`)
 - Requires `ffmpeg` for video conversion
 - Uses hatch for build system with VCS-based versioning
 - Main branch protected, requires PR reviews

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -392,6 +392,7 @@ def _create_nwb(
         rec_filepaths,
         timestamps=rec_dci_timestamps,
         behavior_only=behavior_only,
+        metadata=metadata,
     )
     logger.info("ADDING SAMPLE COUNTS")
     add_sample_count(nwb_file, rec_dci)

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -50,6 +50,15 @@ class SensorConfig:
     description: str
     pattern: str | None = None
 
+    def __post_init__(self):
+        if not np.isfinite(self.conversion) or self.conversion == 0:
+            raise ValueError(
+                f"SensorConfig.conversion must be finite and nonzero, "
+                f"got {self.conversion!r}"
+            )
+        if not self.unit:
+            raise ValueError("SensorConfig.unit must be a non-empty string")
+
 
 # IMU values are stored in SI units (the NWB convention): the TimeSeries
 # ``conversion`` maps the raw int16 counts to the SI unit. The SpikeGadgets sensor
@@ -86,7 +95,16 @@ SENSOR_TYPE_CONFIG: dict[str, SensorConfig] = {
         conversion=1.0,  # raw counts; no counts->volts factor is defined
         unit="unspecified",
         description="ECU analog input",
-        pattern=r"(ECU_Ain\d+|Controller_Ain\d+)$",
+        pattern=r"ECU_Ain\d+$",
+    ),
+    # Controller analog inputs ride the multiplexed/aux stream (not the continuous
+    # ECU stream), so they are categorized separately to keep acquisition names
+    # unambiguous: "analog_input" is always the full-rate ECU stream.
+    "controller_analog_input": SensorConfig(
+        conversion=1.0,  # raw counts; no counts->volts factor is defined
+        unit="unspecified",
+        description="Controller analog input",
+        pattern=r"Controller_Ain\d+$",
     ),
 }
 
@@ -381,6 +399,15 @@ def add_analog_data(
             config = _config_for(sensor_type)
             if sensor_type == "other":
                 _warn_other_channels(channel_names, logger)
+            sensor_timestamps = np.concatenate(time_parts)
+            # The continuous (ECU) path inherits the iterator's monotonicity check;
+            # the decimated path builds its own timestamps, so check them here.
+            if np.any(np.diff(sensor_timestamps) <= 0):
+                logger.warning(
+                    "Decimated timestamps for headstage sensor '%s' are not "
+                    "strictly increasing (clock regression at a file boundary?).",
+                    sensor_type,
+                )
             nwbfile.add_acquisition(
                 pynwb.TimeSeries(
                     name=_unique_acquisition_name(nwbfile, sensor_type, logger),
@@ -388,7 +415,7 @@ def add_analog_data(
                     data=np.concatenate(data_parts),
                     unit=_resolve_sensor_unit(sensor_type, config.unit, metadata),
                     conversion=config.conversion,
-                    timestamps=np.concatenate(time_parts),
+                    timestamps=sensor_timestamps,
                 )
             )
 

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -1,5 +1,6 @@
 """Module for handling the conversion of ECU analog and headstage sensor data streams from Trodes .rec files to NWB format."""
 
+import logging
 import re
 from xml.etree import ElementTree
 
@@ -7,6 +8,7 @@ import h5py
 import numpy as np
 import pynwb
 from hdmf.backends.hdf5 import H5DataIO
+from hdmf.data_utils import GenericDataChunkIterator
 from pynwb import NWBFile
 
 from trodes_to_nwb import convert_rec_header
@@ -134,14 +136,65 @@ def _resolve_sensor_unit(
     return default_unit
 
 
+class _AnalogChannelSubsetIterator(GenericDataChunkIterator):
+    """Lazily yield a fixed subset of channel columns from a shared analog iterator.
+
+    Reuses the source ``RecFileDataChunkIterator``'s multi-file, demux-correct
+    reads. Stores raw int16 values unchanged; physical scaling is carried by the
+    owning ``TimeSeries.conversion`` field, so nothing is upcast or materialized
+    here.
+
+    Parameters
+    ----------
+    source : RecFileDataChunkIterator
+        Shared iterator over the combined analog stream (ECU analog channels
+        followed by multiplexed headstage channels).
+    column_indices : list[int]
+        Column positions, into the combined stream, for this sensor's channels,
+        in output order.
+    """
+
+    def __init__(self, source, column_indices):
+        self._source = source
+        self._column_indices = list(column_indices)
+        self._n_time, self._n_source_cols = source._get_maxshape()
+        super().__init__()
+
+    def _get_data(self, selection: tuple[slice, slice]) -> np.ndarray:
+        # Read this time-chunk across all source columns (cheap: tens of columns
+        # from one packet stream), then pick out the columns for this sensor.
+        # selection bounds are concrete integers supplied by the base class.
+        full = self._source._get_data((selection[0], slice(0, self._n_source_cols)))
+        subset = full[:, self._column_indices]
+        return subset[:, selection[1]]
+
+    def _get_maxshape(self) -> tuple[int, int]:
+        return (self._n_time, len(self._column_indices))
+
+    def _get_dtype(self) -> np.dtype:
+        return np.dtype("int16")
+
+
 def add_analog_data(
     nwbfile: NWBFile,
     rec_file_path: list[str],
     timestamps: np.ndarray = None,
     behavior_only: bool = False,
+    metadata: dict | None = None,
     **kwargs,
 ) -> None:
-    """Adds analog streams to the nwb file.
+    """Adds analog streams to the nwb file as separate, scaled acquisition TimeSeries.
+
+    Headstage IMU sensors (accelerometer, gyroscope, magnetometer) and ECU
+    analog inputs are written as individual ``TimeSeries`` in
+    ``nwbfile.acquisition``, one per sensor type, with the physical unit and
+    scaling carried by each ``TimeSeries.conversion`` field. Data stays lazy and
+    chunked via ``H5DataIO``: raw int16 samples are stored unchanged and scaling
+    is applied on read (``stored * conversion``), so memory use is independent of
+    session length.
+
+    Channels matching no known sensor pattern are written, unscaled, to an
+    ``"other"`` acquisition stream and logged at WARNING.
 
     Parameters
     ----------
@@ -153,58 +206,78 @@ def add_analog_data(
         Array of timestamps for the analog data.
     behavior_only : bool, optional
         Whether to process only behavior data, by default False.
+    metadata : dict, optional
+        Metadata dictionary. A ``"sensor_units"`` mapping may override the unit
+        *label* of any sensor type (it does not change the numeric conversion).
     **kwargs
         Additional keyword arguments.
     """
-    # TODO: ADD HEADSTAGE DATA
+    logger = logging.getLogger("convert")
 
-    # get the ids of the analog channels from the first rec file header
-    analog_channel_ids = _get_ecu_analog_channel_ids(rec_file_path[0])
-
-    # make the data chunk iterator
-    # TODO use the stream name instead of the stream index to be more robust
+    # ECU analog channels come first in the combined stream, then the multiplexed
+    # headstage sensor channels appended by RecFileDataChunkIterator.
+    ecu_analog_ids = _get_ecu_analog_channel_ids(rec_file_path[0])
     rec_dci = RecFileDataChunkIterator(
         rec_file_path,
-        nwb_hw_channel_order=analog_channel_ids,
+        nwb_hw_channel_order=ecu_analog_ids,
         stream_id="ECU_analog",
         is_analog=True,
         timestamps=timestamps,
         behavior_only=behavior_only,
     )
-
-    # add headstage channel IDs to the list of analog channel IDs
-    analog_channel_ids.extend(rec_dci.neo_io[0].multiplexed_channel_xml.keys())
-
-    # (16384, 32) chunks of dtype int16 (2 bytes) is 1 MB, which is recommended
-    # by studies by the NWB team.
-    # could also add compression here. zstd/blosc-zstd are recommended by the NWB team, but
-    # they require the hdf5plugin library to be installed. gzip is available by default.
-    data_data_io = H5DataIO(
-        rec_dci,
-        chunks=(
-            DEFAULT_CHUNK_TIME_DIM,
-            min(len(analog_channel_ids), DEFAULT_CHUNK_MAX_CHANNEL_DIM),
-        ),
-    )
-
-    # make the objects to add to the nwb file
-    nwbfile.create_processing_module(
-        name="analog", description="Contains all analog data"
-    )
-    analog_events = pynwb.behavior.BehavioralEvents(name="analog")
-    analog_events.add_timeseries(
-        pynwb.TimeSeries(
-            name="analog",
-            description=__merge_row_description(
-                analog_channel_ids
-            ),  # NOTE: matches rec_to_nwb system
-            data=data_data_io,
-            timestamps=rec_dci.timestamps,
-            unit="-1",
+    multiplexed_ids = list(rec_dci.neo_io[0].multiplexed_channel_xml.keys())
+    all_channel_ids = ecu_analog_ids + multiplexed_ids
+    if not all_channel_ids:
+        logger.info(
+            "No analog channels found in %s; skipping analog data.", rec_file_path[0]
         )
-    )
-    # add it to the nwb file
-    nwbfile.processing["analog"].add(analog_events)
+        return
+
+    groups = _categorize_sensor_channels(all_channel_ids)
+
+    # Cap the time-axis chunk at the session length so short sessions (fewer than
+    # DEFAULT_CHUNK_TIME_DIM samples) get a valid HDF5 chunk shape.
+    n_time = rec_dci._get_maxshape()[0]
+    chunk_time_dim = min(DEFAULT_CHUNK_TIME_DIM, n_time)
+
+    # All sensor streams share one timestamps dataset: the first TimeSeries owns
+    # it; the rest link to that object so pynwb stores it only once.
+    shared_timestamps = rec_dci.timestamps
+    first_ts = None
+    for sensor_type, channel_names in groups.items():
+        if sensor_type == "other":
+            logger.warning(
+                "Analog channels matched no known sensor pattern and are stored "
+                "raw (unit='unspecified') under acquisition['other']: %s",
+                channel_names,
+            )
+            config = _OTHER_CONFIG
+        else:
+            config = SENSOR_TYPE_CONFIG[sensor_type]
+
+        column_indices = [all_channel_ids.index(name) for name in channel_names]
+        data_iter = _AnalogChannelSubsetIterator(rec_dci, column_indices)
+        data_io = H5DataIO(
+            data_iter,
+            chunks=(
+                chunk_time_dim,
+                min(len(column_indices), DEFAULT_CHUNK_MAX_CHANNEL_DIM),
+            ),
+        )
+        unit = _resolve_sensor_unit(sensor_type, config["unit"], metadata)
+        description = f"{config['description']}: {', '.join(channel_names)}"
+
+        timeseries = pynwb.TimeSeries(
+            name=sensor_type,
+            description=description,
+            data=data_io,
+            unit=unit,
+            conversion=config["conversion"],
+            timestamps=(first_ts if first_ts is not None else shared_timestamps),
+        )
+        nwbfile.add_acquisition(timeseries)
+        if first_ts is None:
+            first_ts = timeseries
 
 
 _NWB_ANALOG_DATA_PATH = "processing/analog/analog/analog/data"
@@ -222,6 +295,11 @@ def update_analog_data(
     Use this function to fix NWB files created before the analog demuxing bug
     was corrected (where ``interleavedDataIDByte`` was not offset by the device
     start byte, causing multiplexed channels to be read incorrectly).
+
+    This targets the *legacy* file layout, where analog data lives in a single
+    combined ``processing/analog/analog/analog/data`` stream. Files written by
+    the current :func:`add_analog_data` instead store per-sensor TimeSeries in
+    ``acquisition`` and are not handled here.
 
     Parameters
     ----------
@@ -274,10 +352,6 @@ def update_analog_data(
         # Write data chunk-by-chunk to avoid loading the full dataset into memory
         for chunk in rec_dci:
             dataset[chunk.selection] = chunk.data
-
-
-def __merge_row_description(row_ids: list[str]) -> str:
-    return "   ".join(row_ids) + "   "
 
 
 def get_analog_channel_names(header: ElementTree) -> list[str]:

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -157,7 +157,13 @@ class _AnalogChannelSubsetIterator(GenericDataChunkIterator):
     def __init__(self, source, column_indices):
         self._source = source
         self._column_indices = list(column_indices)
-        self._n_time, self._n_source_cols = source._get_maxshape()
+        self._n_time, self._n_source_cols = source.maxshape
+        invalid = [i for i in self._column_indices if not 0 <= i < self._n_source_cols]
+        if invalid:
+            raise ValueError(
+                f"column_indices {invalid} are out of range for a source with "
+                f"{self._n_source_cols} columns"
+            )
         super().__init__()
 
     def _get_data(self, selection: tuple[slice, slice]) -> np.ndarray:
@@ -183,7 +189,7 @@ def add_analog_data(
     metadata: dict | None = None,
     **kwargs,
 ) -> None:
-    """Adds analog streams to the nwb file as separate, scaled acquisition TimeSeries.
+    """Adds analog streams as separate acquisition TimeSeries with physical units.
 
     Headstage IMU sensors (accelerometer, gyroscope, magnetometer) and ECU
     analog inputs are written as individual ``TimeSeries`` in
@@ -235,9 +241,22 @@ def add_analog_data(
 
     groups = _categorize_sensor_channels(all_channel_ids)
 
+    # Warn on sensor_units overrides that name an unknown sensor type, so a typo
+    # (e.g. "accel" instead of "accelerometer") is not silently ignored.
+    if metadata and "sensor_units" in metadata:
+        valid_sensor_types = set(SENSOR_TYPE_CONFIG) | {"other"}
+        unknown = set(metadata["sensor_units"]) - valid_sensor_types
+        if unknown:
+            logger.warning(
+                "metadata['sensor_units'] has unrecognized sensor type(s) %s; "
+                "those unit overrides are ignored. Valid keys: %s",
+                sorted(unknown),
+                sorted(valid_sensor_types),
+            )
+
     # Cap the time-axis chunk at the session length so short sessions (fewer than
     # DEFAULT_CHUNK_TIME_DIM samples) get a valid HDF5 chunk shape.
-    n_time = rec_dci._get_maxshape()[0]
+    n_time = rec_dci.maxshape[0]
     chunk_time_dim = min(DEFAULT_CHUNK_TIME_DIM, n_time)
 
     # All sensor streams share one timestamps dataset: the first TimeSeries owns
@@ -322,6 +341,19 @@ def update_analog_data(
     """
     # Reconstruct the same analog channel ID list used in the original conversion
     analog_channel_ids = _get_ecu_analog_channel_ids(rec_file_path[0])
+
+    # Guard: this tool only repairs the legacy combined-analog layout. Files
+    # written by the current add_analog_data store per-sensor TimeSeries in
+    # acquisition and have no processing/analog stream to repair.
+    with h5py.File(nwb_file_path, "r") as f:
+        if _NWB_ANALOG_DATA_PATH not in f:
+            raise ValueError(
+                f"{nwb_file_path!r} has no legacy combined analog stream at "
+                f"{_NWB_ANALOG_DATA_PATH!r}. update_analog_data only repairs files "
+                "written by the pre-sensor-separation layout; files written by the "
+                "current add_analog_data store per-sensor TimeSeries in acquisition "
+                "and need no demux repair."
+            )
 
     # Read timestamps from the existing NWB file if not provided
     if timestamps is None:

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -13,7 +13,7 @@ import pynwb
 from pynwb import NWBFile
 
 from trodes_to_nwb import convert_rec_header
-from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator, concatenate_systime
 from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 
 DEFAULT_CHUNK_TIME_DIM = 16384
@@ -199,13 +199,18 @@ class _AnalogChannelSubsetIterator(GenericDataChunkIterator):
     owning ``TimeSeries.conversion`` field, so nothing is upcast or materialized
     here.
 
+    The source must be built with ``include_multiplexed=False`` so its
+    ``maxshape`` covers only the physical ECU columns; otherwise every read would
+    materialize the whole-file sample-and-held multiplexed array (the regression
+    this path exists to avoid).
+
     Parameters
     ----------
     source : RecFileDataChunkIterator
-        Shared iterator over the combined analog stream (ECU analog channels
-        followed by multiplexed headstage channels).
+        Shared iterator over the physical ECU analog channels (built with
+        ``include_multiplexed=False``).
     column_indices : list[int]
-        Column positions, into the combined stream, for this sensor's channels,
+        Column positions, into the source stream, for this sensor's channels,
         in output order.
     """
 
@@ -280,20 +285,6 @@ def _unique_acquisition_name(
     return name
 
 
-def _derive_analog_timestamps(neo_ios: list) -> np.ndarray:
-    """Per-packet timestamps (concatenated across files) without an ECU stream.
-
-    Mirrors :class:`RecFileDataChunkIterator`'s timestamp derivation so
-    headstage-only files (which have no ``ECU_analog`` stream to build an
-    iterator from) still get timestamps for their decimated sensor streams.
-    """
-    if neo_ios[0].sysClock_byte:
-        return np.concatenate([io.get_regressed_systime(0, None) for io in neo_ios])
-    return np.concatenate(
-        [io.get_systime_from_trodes_timestamps(0, None) for io in neo_ios]
-    )
-
-
 def _open_headstage_only_sources(
     rec_file_path: list[str], timestamps: np.ndarray | None
 ) -> tuple[list, list[int], np.ndarray]:
@@ -303,13 +294,15 @@ def _open_headstage_only_sources(
     attributes ``add_analog_data`` would otherwise read off a
     ``RecFileDataChunkIterator`` (the readers, per-file packet counts, and the
     shared timestamps vector), without requiring an ``ECU_analog`` stream.
+    Timestamps are derived (when not supplied) with the same clock-source rule
+    the iterator uses, via :func:`concatenate_systime`.
     """
     neo_ios = [SpikeGadgetsRawIO(filename=path) for path in rec_file_path]
     for io in neo_ios:
         io.parse_header()
     n_time = [io._raw_memmap.shape[0] for io in neo_ios]
     if timestamps is None:
-        timestamps = _derive_analog_timestamps(neo_ios)
+        timestamps = concatenate_systime(neo_ios)
     return neo_ios, n_time, timestamps
 
 
@@ -403,7 +396,7 @@ def add_analog_data(
     # --- ECU analog inputs: continuous, lazy, full acquisition rate ---
     if ecu_analog_ids:
         chunk_time_dim = min(DEFAULT_CHUNK_TIME_DIM, rec_dci.maxshape[0])
-        ecu_timestamps = rec_dci.timestamps  # shared by all ECU streams (linked once)
+        # shared_timestamps is rec_dci.timestamps here; all ECU streams link to it
         ecu_column = {name: index for index, name in enumerate(ecu_analog_ids)}
         first_ecu_ts = None
         for sensor_type, channel_names in _categorize_sensor_channels(
@@ -427,7 +420,7 @@ def add_analog_data(
                 unit=_resolve_sensor_unit(sensor_type, config.unit, metadata),
                 conversion=config.conversion,
                 timestamps=(
-                    first_ecu_ts if first_ecu_ts is not None else ecu_timestamps
+                    first_ecu_ts if first_ecu_ts is not None else shared_timestamps
                 ),
             )
             nwbfile.add_acquisition(ts)

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -315,6 +315,7 @@ def add_analog_data(
     if ecu_analog_ids:
         chunk_time_dim = min(DEFAULT_CHUNK_TIME_DIM, rec_dci.maxshape[0])
         ecu_timestamps = rec_dci.timestamps  # shared by all ECU streams (linked once)
+        ecu_column = {name: index for index, name in enumerate(ecu_analog_ids)}
         first_ecu_ts = None
         for sensor_type, channel_names in _categorize_sensor_channels(
             ecu_analog_ids
@@ -322,7 +323,7 @@ def add_analog_data(
             config = _config_for(sensor_type)
             if sensor_type == "other":
                 _warn_other_channels(channel_names, logger)
-            column_indices = [ecu_analog_ids.index(name) for name in channel_names]
+            column_indices = [ecu_column[name] for name in channel_names]
             data_io = H5DataIO(
                 _AnalogChannelSubsetIterator(rec_dci, column_indices),
                 chunks=(

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -14,13 +14,18 @@ from pynwb import NWBFile
 
 from trodes_to_nwb import convert_rec_header
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 
 DEFAULT_CHUNK_TIME_DIM = 16384
 DEFAULT_CHUNK_MAX_CHANNEL_DIM = 32
 
 
 def _get_ecu_analog_channel_ids(rec_file_path: str) -> list[str]:
-    """Returns the ordered list of ECU analog channel IDs from the rec file header."""
+    """Returns the ordered list of ECU analog channel IDs from the rec file header.
+
+    Returns an empty list when the recording has no ECU device (e.g. a
+    headstage-only file), rather than raising.
+    """
     root = convert_rec_header.read_header(rec_file_path)
     hconf = root.find("HardwareConfiguration")
     ecu_conf = None
@@ -28,6 +33,8 @@ def _get_ecu_analog_channel_ids(rec_file_path: str) -> list[str]:
         if conf.attrib["name"] == "ECU":
             ecu_conf = conf
             break
+    if ecu_conf is None:
+        return []
     return [
         channel.attrib["id"]
         for channel in ecu_conf
@@ -72,30 +79,38 @@ GYRO_DPS_PER_LSB = 0.061
 
 # Sensor type registry. Patterns are anchored with ``$`` so the axis / Ain-number
 # group is the whole channel-name suffix (``Headstage_AccelXfoo`` does not match).
+# The IMU patterns accept both the modern ``Headstage_AccelX`` channel ids and the
+# bare ``AccelX`` ids that Trodes uses internally (the ``headstageSensor`` device).
 SENSOR_TYPE_CONFIG: dict[str, SensorConfig] = {
     "accelerometer": SensorConfig(
         conversion=ACCEL_G_PER_LSB * STANDARD_GRAVITY_M_S2,
         unit="m/s^2",
         description="Headstage accelerometer, +/-2 g full scale (0.000061 g/LSB)",
-        pattern=r"Headstage_Accel[XYZ]$",
+        pattern=r"(?:Headstage_)?Accel[XYZ]$",
     ),
     "gyroscope": SensorConfig(
         conversion=GYRO_DPS_PER_LSB * DEG_TO_RAD,
         unit="rad/s",
         description="Headstage gyroscope, +/-2000 deg/s full scale (0.061 deg/s/LSB)",
-        pattern=r"Headstage_Gyro[XYZ]$",
+        pattern=r"(?:Headstage_)?Gyro[XYZ]$",
     ),
     "magnetometer": SensorConfig(
         conversion=1.0,  # no calibrated magnetometer scaling is defined
         unit="unspecified",
         description="Headstage magnetometer",
-        pattern=r"Headstage_Mag[XYZ]$",
+        pattern=r"(?:Headstage_)?Mag[XYZ]$",
     ),
     "analog_input": SensorConfig(
         conversion=1.0,  # raw counts; no counts->volts factor is defined
         unit="unspecified",
         description="ECU analog input",
         pattern=r"ECU_Ain\d+$",
+    ),
+    "analog_output": SensorConfig(
+        conversion=1.0,  # raw counts; no counts->volts factor is defined
+        unit="unspecified",
+        description="ECU analog output",
+        pattern=r"ECU_Aout\d+$",
     ),
     # Controller analog inputs ride the multiplexed/aux stream (not the continuous
     # ECU stream), so they are categorized separately to keep acquisition names
@@ -265,6 +280,39 @@ def _unique_acquisition_name(
     return name
 
 
+def _derive_analog_timestamps(neo_ios: list) -> np.ndarray:
+    """Per-packet timestamps (concatenated across files) without an ECU stream.
+
+    Mirrors :class:`RecFileDataChunkIterator`'s timestamp derivation so
+    headstage-only files (which have no ``ECU_analog`` stream to build an
+    iterator from) still get timestamps for their decimated sensor streams.
+    """
+    if neo_ios[0].sysClock_byte:
+        return np.concatenate([io.get_regressed_systime(0, None) for io in neo_ios])
+    return np.concatenate(
+        [io.get_systime_from_trodes_timestamps(0, None) for io in neo_ios]
+    )
+
+
+def _open_headstage_only_sources(
+    rec_file_path: list[str], timestamps: np.ndarray | None
+) -> tuple[list, list[int], np.ndarray]:
+    """Open rec readers directly for files with multiplexed sensors but no ECU.
+
+    Returns ``(neo_ios, n_time, timestamps)`` providing the same handful of
+    attributes ``add_analog_data`` would otherwise read off a
+    ``RecFileDataChunkIterator`` (the readers, per-file packet counts, and the
+    shared timestamps vector), without requiring an ``ECU_analog`` stream.
+    """
+    neo_ios = [SpikeGadgetsRawIO(filename=path) for path in rec_file_path]
+    for io in neo_ios:
+        io.parse_header()
+    n_time = [io._raw_memmap.shape[0] for io in neo_ios]
+    if timestamps is None:
+        timestamps = _derive_analog_timestamps(neo_ios)
+    return neo_ios, n_time, timestamps
+
+
 def add_analog_data(
     nwbfile: NWBFile,
     rec_file_path: list[str],
@@ -286,14 +334,17 @@ def add_analog_data(
       acquisition rate by sample-and-hold in the ``.rec`` stream. These are
       *decimated* back to their true rate using the per-packet update flags and
       stored with explicit ``timestamps`` taken from the genuinely-sampled
-      packets. Accelerometer and gyroscope are sampled on interleaved schedules,
-      so each sensor gets its own timestamps. A sensor that never updates (a
-      disabled sensor) is omitted with a WARNING.
+      packets. Each sensor's channels are partitioned by their update schedule
+      (``interleavedDataIDByte``/``Bit``) so co-sampled channels share one
+      timestamp vector; if a sensor's channels update on different schedules they
+      are written as separate streams. A sensor that never updates (a disabled
+      sensor) is omitted with a WARNING.
 
     Every sensor type is written as its own ``TimeSeries`` in
     ``nwbfile.acquisition`` with the physical unit and scaling carried by
     ``TimeSeries.conversion``. Channels matching no known pattern go to an
-    ``"other"`` stream and are logged at WARNING.
+    ``"other"`` stream and are logged at WARNING. Files with no ECU device
+    (headstage-only recordings) write only the multiplexed sensor streams.
 
     Parameters
     ----------
@@ -314,15 +365,33 @@ def add_analog_data(
     logger = logging.getLogger("convert")
 
     ecu_analog_ids = _get_ecu_analog_channel_ids(rec_file_path[0])
-    rec_dci = RecFileDataChunkIterator(
-        rec_file_path,
-        nwb_hw_channel_order=ecu_analog_ids,
-        stream_id="ECU_analog",
-        is_analog=True,
-        timestamps=timestamps,
-        behavior_only=behavior_only,
-    )
-    multiplexed_ids = list(rec_dci.neo_io[0].multiplexed_channel_xml.keys())
+
+    # ECU analog inputs and multiplexed headstage sensors are read through
+    # different paths. Build the continuous-rate ECU iterator only when ECU analog
+    # channels exist (headstage-only files have none); the multiplexed sensors are
+    # read straight off the rec readers either way. The ECU iterator is built with
+    # include_multiplexed=False so reading the physical ECU columns never
+    # materializes the whole-file sample-and-held multiplexed array.
+    rec_dci = None
+    if ecu_analog_ids:
+        rec_dci = RecFileDataChunkIterator(
+            rec_file_path,
+            nwb_hw_channel_order=ecu_analog_ids,
+            stream_id="ECU_analog",
+            is_analog=True,
+            timestamps=timestamps,
+            behavior_only=behavior_only,
+            include_multiplexed=False,
+        )
+        neo_ios = rec_dci.neo_io
+        n_time = rec_dci.n_time
+        shared_timestamps = rec_dci.timestamps
+    else:
+        neo_ios, n_time, shared_timestamps = _open_headstage_only_sources(
+            rec_file_path, timestamps
+        )
+
+    multiplexed_ids = list(neo_ios[0].multiplexed_channel_xml.keys())
     if not ecu_analog_ids and not multiplexed_ids:
         logger.info(
             "No analog channels found in %s; skipping analog data.", rec_file_path[0]
@@ -369,50 +438,59 @@ def add_analog_data(
     if multiplexed_ids:
         # global packet offset of each rec file, to map per-file update indices
         # onto the shared (concatenated) timestamps vector
-        file_start = np.append(0, np.cumsum(rec_dci.n_time)).astype(int)
+        file_start = np.append(0, np.cumsum(n_time)).astype(int)
         for sensor_type, channel_names in _categorize_sensor_channels(
             multiplexed_ids
         ).items():
-            data_parts, time_parts = [], []
-            for file_index, neo_io in enumerate(rec_dci.neo_io):
-                file_data, update_indices = (
-                    neo_io.get_analogsignal_multiplexed_decimated(channel_names)
-                )
-                if update_indices.size:
-                    data_parts.append(file_data)
-                    time_parts.append(
-                        rec_dci.timestamps[file_start[file_index] + update_indices]
-                    )
-            if not data_parts:
-                logger.warning(
-                    "Headstage sensor '%s' (%s) has no sampled data (disabled); "
-                    "skipping.",
-                    sensor_type,
-                    channel_names,
-                )
-                continue
             config = SENSOR_TYPE_CONFIG.get(sensor_type, _OTHER_CONFIG)
-            if sensor_type == "other":
-                _warn_other_channels(channel_names, logger)
-            sensor_timestamps = np.concatenate(time_parts)
-            # The continuous (ECU) path inherits the iterator's monotonicity check;
-            # the decimated path builds its own timestamps, so check them here.
-            if np.any(np.diff(sensor_timestamps) <= 0):
-                logger.warning(
-                    "Decimated timestamps for headstage sensor '%s' are not "
-                    "strictly increasing (clock regression at a file boundary?).",
-                    sensor_type,
-                )
-            nwbfile.add_acquisition(
-                pynwb.TimeSeries(
-                    name=_unique_acquisition_name(nwbfile, sensor_type, logger),
-                    description=f"{config.description}: {', '.join(channel_names)}",
-                    data=np.concatenate(data_parts),
-                    unit=_resolve_sensor_unit(sensor_type, config.unit, metadata),
-                    conversion=config.conversion,
-                    timestamps=sensor_timestamps,
-                )
+            # A sensor's channels are not guaranteed to share an update schedule, so
+            # split by (interleavedDataIDByte, interleavedDataIDBit): each group is a
+            # genuinely co-sampled stream rather than assuming one sensor == one
+            # timestamp vector. Co-scheduled axes (the common case) stay one stream;
+            # divergent schedules become separate streams (disambiguated by name).
+            schedule_groups = neo_ios[0].group_multiplexed_channels_by_schedule(
+                channel_names
             )
+            for group in schedule_groups:
+                data_parts, time_parts = [], []
+                for file_index, neo_io in enumerate(neo_ios):
+                    file_data, update_indices = (
+                        neo_io.get_analogsignal_multiplexed_decimated(group)
+                    )
+                    if update_indices.size:
+                        data_parts.append(file_data)
+                        time_parts.append(
+                            shared_timestamps[file_start[file_index] + update_indices]
+                        )
+                if not data_parts:
+                    logger.warning(
+                        "Headstage sensor '%s' (%s) has no sampled data (disabled); "
+                        "skipping.",
+                        sensor_type,
+                        group,
+                    )
+                    continue
+                if sensor_type == "other":
+                    _warn_other_channels(group, logger)
+                sensor_timestamps = np.concatenate(time_parts)
+                # The continuous (ECU) path inherits the iterator's monotonicity
+                # check; the decimated path builds its own timestamps, check here.
+                if np.any(np.diff(sensor_timestamps) <= 0):
+                    logger.warning(
+                        "Decimated timestamps for headstage sensor '%s' are not "
+                        "strictly increasing (clock regression at a file boundary?).",
+                        sensor_type,
+                    )
+                nwbfile.add_acquisition(
+                    pynwb.TimeSeries(
+                        name=_unique_acquisition_name(nwbfile, sensor_type, logger),
+                        description=f"{config.description}: {', '.join(group)}",
+                        data=np.concatenate(data_parts),
+                        unit=_resolve_sensor_unit(sensor_type, config.unit, metadata),
+                        conversion=config.conversion,
+                        timestamps=sensor_timestamps,
+                    )
+                )
 
 
 _NWB_ANALOG_DATA_PATH = "processing/analog/analog/analog/data"
@@ -513,7 +591,8 @@ def get_analog_channel_names(header: ElementTree) -> list[str]:
     Returns
     -------
     list[str]
-        List of the names of the analog channels in the rec file
+        List of the names of the analog channels in the rec file. Empty if the
+        recording has no ECU device (e.g. a headstage-only file).
     """
     hconf = header.find("HardwareConfiguration")
     ecu_conf = None
@@ -522,6 +601,8 @@ def get_analog_channel_names(header: ElementTree) -> list[str]:
         if conf.attrib["name"] == "ECU":
             ecu_conf = conf
             break
+    if ecu_conf is None:
+        return []
     # get the names of the analog channels
     analog_channel_names = []
     for channel in ecu_conf:

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -221,11 +221,6 @@ class _AnalogChannelSubsetIterator(GenericDataChunkIterator):
         return np.dtype("int16")
 
 
-def _config_for(sensor_type: str) -> SensorConfig:
-    """Return the SensorConfig for a sensor type, or the catch-all for ``other``."""
-    return SENSOR_TYPE_CONFIG.get(sensor_type, _OTHER_CONFIG)
-
-
 def _warn_other_channels(channel_names: list[str], logger: logging.Logger) -> None:
     logger.warning(
         "Analog channels matched no known sensor pattern and are stored raw "
@@ -345,7 +340,7 @@ def add_analog_data(
         for sensor_type, channel_names in _categorize_sensor_channels(
             ecu_analog_ids
         ).items():
-            config = _config_for(sensor_type)
+            config = SENSOR_TYPE_CONFIG.get(sensor_type, _OTHER_CONFIG)
             if sensor_type == "other":
                 _warn_other_channels(channel_names, logger)
             column_indices = [ecu_column[name] for name in channel_names]
@@ -396,7 +391,7 @@ def add_analog_data(
                     channel_names,
                 )
                 continue
-            config = _config_for(sensor_type)
+            config = SENSOR_TYPE_CONFIG.get(sensor_type, _OTHER_CONFIG)
             if sensor_type == "other":
                 _warn_other_channels(channel_names, logger)
             sensor_timestamps = np.concatenate(time_parts)

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -1,14 +1,15 @@
 """Module for handling the conversion of ECU analog and headstage sensor data streams from Trodes .rec files to NWB format."""
 
+from dataclasses import dataclass
 import logging
 import re
 from xml.etree import ElementTree
 
 import h5py
-import numpy as np
-import pynwb
 from hdmf.backends.hdf5 import H5DataIO
 from hdmf.data_utils import GenericDataChunkIterator
+import numpy as np
+import pynwb
 from pynwb import NWBFile
 
 from trodes_to_nwb import convert_rec_header
@@ -34,46 +35,60 @@ def _get_ecu_analog_channel_ids(rec_file_path: str) -> list[str]:
     ]
 
 
-# Sensor type registry. ``conversion`` is the NWB ``TimeSeries.conversion`` factor
-# (stored_int16 * conversion = value in ``unit``), NOT a pre-multiplier applied to
-# the array. Patterns are anchored with ``$`` so the axis / Ain-number group is the
-# whole channel-name suffix (``Headstage_AccelXfoo`` does not match). The headstage
-# IMU scaling factors are the SpikeGadgets sensor sensitivities:
+@dataclass(frozen=True)
+class SensorConfig:
+    """Scaling/unit/naming for one analog sensor type.
+
+    ``conversion`` is the NWB ``TimeSeries.conversion`` factor
+    (``stored_int16 * conversion = value in unit``), NOT a pre-multiplier applied
+    to the array. ``pattern`` is an anchored regex matching this sensor's channel
+    names, or ``None`` for the catch-all ("other") bucket that matches no pattern.
+    """
+
+    conversion: float
+    unit: str
+    description: str
+    pattern: str | None = None
+
+
+# Sensor type registry. Patterns are anchored with ``$`` so the axis / Ain-number
+# group is the whole channel-name suffix (``Headstage_AccelXfoo`` does not match).
+# The headstage IMU scaling factors are the SpikeGadgets sensor sensitivities:
 # 0.000061 g/LSB = 1/16384 (accelerometer, +/-2 g full scale) and
 # 0.061 deg/s/LSB = 2000/32768 (gyroscope, +/-2000 deg/s full scale).
-SENSOR_TYPE_CONFIG: dict[str, dict] = {
-    "accelerometer": {
-        "pattern": r"Headstage_Accel[XYZ]$",
-        "conversion": 0.000061,
-        "unit": "g",
-        "description": "Headstage accelerometer",
-    },
-    "gyroscope": {
-        "pattern": r"Headstage_Gyro[XYZ]$",
-        "conversion": 0.061,
-        "unit": "d/s",
-        "description": "Headstage gyroscope",
-    },
-    "magnetometer": {
-        "pattern": r"Headstage_Mag[XYZ]$",
-        "conversion": 1.0,  # no calibrated magnetometer scaling is defined
-        "unit": "unspecified",
-        "description": "Headstage magnetometer",
-    },
-    "analog_input": {
-        "pattern": r"(ECU_Ain\d+|Controller_Ain\d+)$",
-        "conversion": 1.0,  # raw counts; no counts->volts factor is defined
-        "unit": "unspecified",
-        "description": "ECU analog input",
-    },
+SENSOR_TYPE_CONFIG: dict[str, SensorConfig] = {
+    "accelerometer": SensorConfig(
+        conversion=0.000061,
+        unit="g",
+        description="Headstage accelerometer",
+        pattern=r"Headstage_Accel[XYZ]$",
+    ),
+    "gyroscope": SensorConfig(
+        conversion=0.061,
+        unit="d/s",
+        description="Headstage gyroscope",
+        pattern=r"Headstage_Gyro[XYZ]$",
+    ),
+    "magnetometer": SensorConfig(
+        conversion=1.0,  # no calibrated magnetometer scaling is defined
+        unit="unspecified",
+        description="Headstage magnetometer",
+        pattern=r"Headstage_Mag[XYZ]$",
+    ),
+    "analog_input": SensorConfig(
+        conversion=1.0,  # raw counts; no counts->volts factor is defined
+        unit="unspecified",
+        description="ECU analog input",
+        pattern=r"(ECU_Ain\d+|Controller_Ain\d+)$",
+    ),
 }
 
-# Used directly (not a SENSOR_TYPE_CONFIG entry) for channels matching no pattern.
-_OTHER_CONFIG = {
-    "conversion": 1.0,
-    "unit": "unspecified",
-    "description": "Uncategorized analog channel",
-}
+# Used for channels matching no pattern (pattern=None marks the catch-all).
+_OTHER_CONFIG = SensorConfig(
+    conversion=1.0,
+    unit="unspecified",
+    description="Uncategorized analog channel",
+)
 
 
 def _categorize_sensor_channels(channel_names: list[str]) -> dict[str, list[str]]:
@@ -94,7 +109,7 @@ def _categorize_sensor_channels(channel_names: list[str]) -> dict[str, list[str]
     """
     categorized: dict[str, list[str]] = {}
     for sensor_type, config in SENSOR_TYPE_CONFIG.items():
-        pattern = config["pattern"]
+        pattern = config.pattern
         matching = [name for name in channel_names if re.match(pattern, name)]
         if matching:
             categorized[sensor_type] = matching
@@ -283,15 +298,15 @@ def add_analog_data(
                 min(len(column_indices), DEFAULT_CHUNK_MAX_CHANNEL_DIM),
             ),
         )
-        unit = _resolve_sensor_unit(sensor_type, config["unit"], metadata)
-        description = f"{config['description']}: {', '.join(channel_names)}"
+        unit = _resolve_sensor_unit(sensor_type, config.unit, metadata)
+        description = f"{config.description}: {', '.join(channel_names)}"
 
         timeseries = pynwb.TimeSeries(
             name=sensor_type,
             description=description,
             data=data_io,
             unit=unit,
-            conversion=config["conversion"],
+            conversion=config.conversion,
             timestamps=(first_ts if first_ts is not None else shared_timestamps),
         )
         nwbfile.add_acquisition(timeseries)

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -1,5 +1,6 @@
 """Module for handling the conversion of ECU analog and headstage sensor data streams from Trodes .rec files to NWB format."""
 
+import re
 from xml.etree import ElementTree
 
 import h5py
@@ -29,6 +30,108 @@ def _get_ecu_analog_channel_ids(rec_file_path: str) -> list[str]:
         for channel in ecu_conf
         if channel.attrib["dataType"] == "analog"
     ]
+
+
+# Sensor type registry. ``conversion`` is the NWB ``TimeSeries.conversion`` factor
+# (stored_int16 * conversion = value in ``unit``), NOT a pre-multiplier applied to
+# the array. Patterns are anchored with ``$`` so the axis / Ain-number group is the
+# whole channel-name suffix (``Headstage_AccelXfoo`` does not match). The headstage
+# IMU scaling factors are the SpikeGadgets sensor sensitivities:
+# 0.000061 g/LSB = 1/16384 (accelerometer, +/-2 g full scale) and
+# 0.061 deg/s/LSB = 2000/32768 (gyroscope, +/-2000 deg/s full scale).
+SENSOR_TYPE_CONFIG: dict[str, dict] = {
+    "accelerometer": {
+        "pattern": r"Headstage_Accel[XYZ]$",
+        "conversion": 0.000061,
+        "unit": "g",
+        "description": "Headstage accelerometer",
+    },
+    "gyroscope": {
+        "pattern": r"Headstage_Gyro[XYZ]$",
+        "conversion": 0.061,
+        "unit": "d/s",
+        "description": "Headstage gyroscope",
+    },
+    "magnetometer": {
+        "pattern": r"Headstage_Mag[XYZ]$",
+        "conversion": 1.0,  # no calibrated magnetometer scaling is defined
+        "unit": "unspecified",
+        "description": "Headstage magnetometer",
+    },
+    "analog_input": {
+        "pattern": r"(ECU_Ain\d+|Controller_Ain\d+)$",
+        "conversion": 1.0,  # raw counts; no counts->volts factor is defined
+        "unit": "unspecified",
+        "description": "ECU analog input",
+    },
+}
+
+# Used directly (not a SENSOR_TYPE_CONFIG entry) for channels matching no pattern.
+_OTHER_CONFIG = {
+    "conversion": 1.0,
+    "unit": "unspecified",
+    "description": "Uncategorized analog channel",
+}
+
+
+def _categorize_sensor_channels(channel_names: list[str]) -> dict[str, list[str]]:
+    """Group channel names by sensor type using ``SENSOR_TYPE_CONFIG`` patterns.
+
+    Parameters
+    ----------
+    channel_names : list[str]
+        Analog channel names to classify.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Insertion-ordered mapping of sensor type to the matching channel names,
+        in the order they appear in ``channel_names``. Channels matching no
+        pattern are grouped under the key ``"other"``. Sensor types with no
+        matching channels are omitted; an empty input returns ``{}``.
+    """
+    categorized: dict[str, list[str]] = {}
+    for sensor_type, config in SENSOR_TYPE_CONFIG.items():
+        pattern = config["pattern"]
+        matching = [name for name in channel_names if re.match(pattern, name)]
+        if matching:
+            categorized[sensor_type] = matching
+
+    assigned = {name for names in categorized.values() for name in names}
+    uncategorized = [name for name in channel_names if name not in assigned]
+    if uncategorized:
+        categorized["other"] = uncategorized
+
+    return categorized
+
+
+def _resolve_sensor_unit(
+    sensor_type: str, default_unit: str, metadata: dict | None
+) -> str:
+    """Resolve the unit *label* for a sensor type.
+
+    Returns ``metadata["sensor_units"][sensor_type]`` when present, otherwise
+    ``default_unit``. The override changes only the label string; it does not
+    change the numeric ``conversion`` factor (that always comes from
+    ``SENSOR_TYPE_CONFIG``).
+
+    Parameters
+    ----------
+    sensor_type : str
+        Bare sensor type key (e.g. ``"accelerometer"``, ``"analog_input"``).
+    default_unit : str
+        Unit to use when no override is supplied.
+    metadata : dict or None
+        Metadata dictionary that may contain a ``"sensor_units"`` mapping.
+
+    Returns
+    -------
+    str
+        The resolved unit label.
+    """
+    if metadata and sensor_type in metadata.get("sensor_units", {}):
+        return metadata["sensor_units"][sensor_type]
+    return default_unit
 
 
 def add_analog_data(

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -51,22 +51,29 @@ class SensorConfig:
     pattern: str | None = None
 
 
+# IMU values are stored in SI units (the NWB convention): the TimeSeries
+# ``conversion`` maps the raw int16 counts to the SI unit. The SpikeGadgets sensor
+# sensitivities are 0.000061 g/LSB = 1/16384 (accelerometer, +/-2 g full scale) and
+# 0.061 deg/s/LSB = 2000/32768 (gyroscope, +/-2000 deg/s full scale); these are
+# converted to m/s^2 and rad/s with the constants below.
+STANDARD_GRAVITY_M_S2 = 9.80665  # standard gravity, m/s^2 (CODATA / ISO 80000)
+DEG_TO_RAD = np.pi / 180.0
+ACCEL_G_PER_LSB = 0.000061
+GYRO_DPS_PER_LSB = 0.061
+
 # Sensor type registry. Patterns are anchored with ``$`` so the axis / Ain-number
 # group is the whole channel-name suffix (``Headstage_AccelXfoo`` does not match).
-# The headstage IMU scaling factors are the SpikeGadgets sensor sensitivities:
-# 0.000061 g/LSB = 1/16384 (accelerometer, +/-2 g full scale) and
-# 0.061 deg/s/LSB = 2000/32768 (gyroscope, +/-2000 deg/s full scale).
 SENSOR_TYPE_CONFIG: dict[str, SensorConfig] = {
     "accelerometer": SensorConfig(
-        conversion=0.000061,
-        unit="g",
-        description="Headstage accelerometer",
+        conversion=ACCEL_G_PER_LSB * STANDARD_GRAVITY_M_S2,
+        unit="m/s^2",
+        description="Headstage accelerometer, +/-2 g full scale (0.000061 g/LSB)",
         pattern=r"Headstage_Accel[XYZ]$",
     ),
     "gyroscope": SensorConfig(
-        conversion=0.061,
-        unit="d/s",
-        description="Headstage gyroscope",
+        conversion=GYRO_DPS_PER_LSB * DEG_TO_RAD,
+        unit="rad/s",
+        description="Headstage gyroscope, +/-2000 deg/s full scale (0.061 deg/s/LSB)",
         pattern=r"Headstage_Gyro[XYZ]$",
     ),
     "magnetometer": SensorConfig(

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -196,6 +196,55 @@ class _AnalogChannelSubsetIterator(GenericDataChunkIterator):
         return np.dtype("int16")
 
 
+def _config_for(sensor_type: str) -> SensorConfig:
+    """Return the SensorConfig for a sensor type, or the catch-all for ``other``."""
+    return SENSOR_TYPE_CONFIG.get(sensor_type, _OTHER_CONFIG)
+
+
+def _warn_other_channels(channel_names: list[str], logger: logging.Logger) -> None:
+    logger.warning(
+        "Analog channels matched no known sensor pattern and are stored raw "
+        "(unit='unspecified') under acquisition['other']: %s",
+        channel_names,
+    )
+
+
+def _warn_unknown_sensor_units(metadata: dict | None, logger: logging.Logger) -> None:
+    """Warn if metadata['sensor_units'] names a sensor type that does not exist."""
+    if metadata and "sensor_units" in metadata:
+        valid = set(SENSOR_TYPE_CONFIG) | {"other"}
+        unknown = set(metadata["sensor_units"]) - valid
+        if unknown:
+            logger.warning(
+                "metadata['sensor_units'] has unrecognized sensor type(s) %s; "
+                "those unit overrides are ignored. Valid keys: %s",
+                sorted(unknown),
+                sorted(valid),
+            )
+
+
+def _unique_acquisition_name(
+    nwbfile: NWBFile, base: str, logger: logging.Logger
+) -> str:
+    """Return ``base``, or a suffixed variant if that name is already taken.
+
+    ECU and headstage sources can both produce a generic category (e.g.
+    ``analog_input``); this keeps acquisition names unique rather than colliding.
+    """
+    if base not in nwbfile.acquisition:
+        return base
+    suffix = 2
+    while f"{base}_{suffix}" in nwbfile.acquisition:
+        suffix += 1
+    name = f"{base}_{suffix}"
+    logger.warning(
+        "Acquisition name '%s' already exists; storing this stream as '%s'.",
+        base,
+        name,
+    )
+    return name
+
+
 def add_analog_data(
     nwbfile: NWBFile,
     rec_file_path: list[str],
@@ -206,16 +255,25 @@ def add_analog_data(
 ) -> None:
     """Adds analog streams as separate acquisition TimeSeries with physical units.
 
-    Headstage IMU sensors (accelerometer, gyroscope, magnetometer) and ECU
-    analog inputs are written as individual ``TimeSeries`` in
-    ``nwbfile.acquisition``, one per sensor type, with the physical unit and
-    scaling carried by each ``TimeSeries.conversion`` field. Data stays lazy and
-    chunked via ``H5DataIO``: raw int16 samples are stored unchanged and scaling
-    is applied on read (``stored * conversion``), so memory use is independent of
-    session length.
+    Two kinds of analog data are handled differently:
 
-    Channels matching no known sensor pattern are written, unscaled, to an
-    ``"other"`` acquisition stream and logged at WARNING.
+    - **ECU analog inputs** (``ECU_Ain*``) are continuously sampled at the
+      acquisition rate. They are stored lazily and chunked via ``H5DataIO``: raw
+      int16 is stored unchanged and scaling is applied on read
+      (``stored * conversion``), so memory use is independent of session length.
+    - **Headstage IMU sensors** (accelerometer, gyroscope, magnetometer) are
+      sampled at the sensor's native rate (~100 Hz) and expanded to the
+      acquisition rate by sample-and-hold in the ``.rec`` stream. These are
+      *decimated* back to their true rate using the per-packet update flags and
+      stored with explicit ``timestamps`` taken from the genuinely-sampled
+      packets. Accelerometer and gyroscope are sampled on interleaved schedules,
+      so each sensor gets its own timestamps. A sensor that never updates (a
+      disabled sensor) is omitted with a WARNING.
+
+    Every sensor type is written as its own ``TimeSeries`` in
+    ``nwbfile.acquisition`` with the physical unit and scaling carried by
+    ``TimeSeries.conversion``. Channels matching no known pattern go to an
+    ``"other"`` stream and are logged at WARNING.
 
     Parameters
     ----------
@@ -235,8 +293,6 @@ def add_analog_data(
     """
     logger = logging.getLogger("convert")
 
-    # ECU analog channels come first in the combined stream, then the multiplexed
-    # headstage sensor channels appended by RecFileDataChunkIterator.
     ecu_analog_ids = _get_ecu_analog_channel_ids(rec_file_path[0])
     rec_dci = RecFileDataChunkIterator(
         rec_file_path,
@@ -247,71 +303,86 @@ def add_analog_data(
         behavior_only=behavior_only,
     )
     multiplexed_ids = list(rec_dci.neo_io[0].multiplexed_channel_xml.keys())
-    all_channel_ids = ecu_analog_ids + multiplexed_ids
-    if not all_channel_ids:
+    if not ecu_analog_ids and not multiplexed_ids:
         logger.info(
             "No analog channels found in %s; skipping analog data.", rec_file_path[0]
         )
         return
 
-    groups = _categorize_sensor_channels(all_channel_ids)
+    _warn_unknown_sensor_units(metadata, logger)
 
-    # Warn on sensor_units overrides that name an unknown sensor type, so a typo
-    # (e.g. "accel" instead of "accelerometer") is not silently ignored.
-    if metadata and "sensor_units" in metadata:
-        valid_sensor_types = set(SENSOR_TYPE_CONFIG) | {"other"}
-        unknown = set(metadata["sensor_units"]) - valid_sensor_types
-        if unknown:
-            logger.warning(
-                "metadata['sensor_units'] has unrecognized sensor type(s) %s; "
-                "those unit overrides are ignored. Valid keys: %s",
-                sorted(unknown),
-                sorted(valid_sensor_types),
+    # --- ECU analog inputs: continuous, lazy, full acquisition rate ---
+    if ecu_analog_ids:
+        chunk_time_dim = min(DEFAULT_CHUNK_TIME_DIM, rec_dci.maxshape[0])
+        ecu_timestamps = rec_dci.timestamps  # shared by all ECU streams (linked once)
+        first_ecu_ts = None
+        for sensor_type, channel_names in _categorize_sensor_channels(
+            ecu_analog_ids
+        ).items():
+            config = _config_for(sensor_type)
+            if sensor_type == "other":
+                _warn_other_channels(channel_names, logger)
+            column_indices = [ecu_analog_ids.index(name) for name in channel_names]
+            data_io = H5DataIO(
+                _AnalogChannelSubsetIterator(rec_dci, column_indices),
+                chunks=(
+                    chunk_time_dim,
+                    min(len(column_indices), DEFAULT_CHUNK_MAX_CHANNEL_DIM),
+                ),
             )
-
-    # Cap the time-axis chunk at the session length so short sessions (fewer than
-    # DEFAULT_CHUNK_TIME_DIM samples) get a valid HDF5 chunk shape.
-    n_time = rec_dci.maxshape[0]
-    chunk_time_dim = min(DEFAULT_CHUNK_TIME_DIM, n_time)
-
-    # All sensor streams share one timestamps dataset: the first TimeSeries owns
-    # it; the rest link to that object so pynwb stores it only once.
-    shared_timestamps = rec_dci.timestamps
-    first_ts = None
-    for sensor_type, channel_names in groups.items():
-        if sensor_type == "other":
-            logger.warning(
-                "Analog channels matched no known sensor pattern and are stored "
-                "raw (unit='unspecified') under acquisition['other']: %s",
-                channel_names,
+            ts = pynwb.TimeSeries(
+                name=_unique_acquisition_name(nwbfile, sensor_type, logger),
+                description=f"{config.description}: {', '.join(channel_names)}",
+                data=data_io,
+                unit=_resolve_sensor_unit(sensor_type, config.unit, metadata),
+                conversion=config.conversion,
+                timestamps=(
+                    first_ecu_ts if first_ecu_ts is not None else ecu_timestamps
+                ),
             )
-            config = _OTHER_CONFIG
-        else:
-            config = SENSOR_TYPE_CONFIG[sensor_type]
+            nwbfile.add_acquisition(ts)
+            if first_ecu_ts is None:
+                first_ecu_ts = ts
 
-        column_indices = [all_channel_ids.index(name) for name in channel_names]
-        data_iter = _AnalogChannelSubsetIterator(rec_dci, column_indices)
-        data_io = H5DataIO(
-            data_iter,
-            chunks=(
-                chunk_time_dim,
-                min(len(column_indices), DEFAULT_CHUNK_MAX_CHANNEL_DIM),
-            ),
-        )
-        unit = _resolve_sensor_unit(sensor_type, config.unit, metadata)
-        description = f"{config.description}: {', '.join(channel_names)}"
-
-        timeseries = pynwb.TimeSeries(
-            name=sensor_type,
-            description=description,
-            data=data_io,
-            unit=unit,
-            conversion=config.conversion,
-            timestamps=(first_ts if first_ts is not None else shared_timestamps),
-        )
-        nwbfile.add_acquisition(timeseries)
-        if first_ts is None:
-            first_ts = timeseries
+    # --- Headstage multiplexed sensors: decimate sample-and-hold to true rate ---
+    if multiplexed_ids:
+        # global packet offset of each rec file, to map per-file update indices
+        # onto the shared (concatenated) timestamps vector
+        file_start = np.append(0, np.cumsum(rec_dci.n_time)).astype(int)
+        for sensor_type, channel_names in _categorize_sensor_channels(
+            multiplexed_ids
+        ).items():
+            data_parts, time_parts = [], []
+            for file_index, neo_io in enumerate(rec_dci.neo_io):
+                file_data, update_indices = (
+                    neo_io.get_analogsignal_multiplexed_decimated(channel_names)
+                )
+                if update_indices.size:
+                    data_parts.append(file_data)
+                    time_parts.append(
+                        rec_dci.timestamps[file_start[file_index] + update_indices]
+                    )
+            if not data_parts:
+                logger.warning(
+                    "Headstage sensor '%s' (%s) has no sampled data (disabled); "
+                    "skipping.",
+                    sensor_type,
+                    channel_names,
+                )
+                continue
+            config = _config_for(sensor_type)
+            if sensor_type == "other":
+                _warn_other_channels(channel_names, logger)
+            nwbfile.add_acquisition(
+                pynwb.TimeSeries(
+                    name=_unique_acquisition_name(nwbfile, sensor_type, logger),
+                    description=f"{config.description}: {', '.join(channel_names)}",
+                    data=np.concatenate(data_parts),
+                    unit=_resolve_sensor_unit(sensor_type, config.unit, metadata),
+                    conversion=config.conversion,
+                    timestamps=np.concatenate(time_parts),
+                )
+            )
 
 
 _NWB_ANALOG_DATA_PATH = "processing/analog/analog/analog/data"

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -33,6 +33,22 @@ DEFAULT_CHUNK_TIME_DIM = 16384
 DEFAULT_CHUNK_MAX_CHANNEL_DIM = 32
 
 
+def concatenate_systime(neo_ios: list) -> np.ndarray:
+    """Concatenated per-packet system-clock timestamps across rec readers.
+
+    Uses the regressed sysClock when the device records one, otherwise derives
+    systime from the Trodes sample counter and sampling rate. Centralizes the
+    clock-source choice so callers that need timestamps without building a full
+    :class:`RecFileDataChunkIterator` (e.g. the analog headstage-only path) stay
+    consistent with the iterator's own derivation.
+    """
+    if neo_ios[0].sysClock_byte:
+        return np.concatenate([io.get_regressed_systime(0, None) for io in neo_ios])
+    return np.concatenate(
+        [io.get_systime_from_trodes_timestamps(0, None) for io in neo_ios]
+    )
+
+
 class RecFileDataChunkIterator(GenericDataChunkIterator):
     """Data chunk iterator for SpikeGadgets rec files."""
 
@@ -93,6 +109,10 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             )
             for file in rec_file_path
         ]  # get all streams for all files
+        # Set the multiplexed-append policy before the large-file split below, so
+        # each SpikeGadgetsRawIOPartial copies the correct value from its full_io.
+        for neo_io in self.neo_io:
+            neo_io._include_analog_multiplexed = include_multiplexed
         logger.info("Parsing headers")
         [neo_io.parse_header() for neo_io in self.neo_io]
         # TODO see what else spikeinterface does and whether it is necessary
@@ -206,25 +226,11 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 self.neo_io.pop(iterator_loc)
                 self.neo_io[iterator_loc:iterator_loc] = sub_iterators
         logger.info(f"# iterators: {len(self.neo_io)}")
-        # propagate the multiplexed-append policy to every (possibly split) reader
-        for neo_io in self.neo_io:
-            neo_io._include_analog_multiplexed = self.include_multiplexed
         # NOTE: this will read all the timestamps from the rec file, which can be slow
         if timestamps is not None:
             self.timestamps = timestamps
-
-        elif self.neo_io[0].sysClock_byte:  # use this if have sysClock
-            self.timestamps = np.concatenate(
-                [neo_io.get_regressed_systime(0, None) for neo_io in self.neo_io]
-            )
-
-        else:  # use this to convert Trodes timestamps into systime based on sampling rate
-            self.timestamps = np.concatenate(
-                [
-                    neo_io.get_systime_from_trodes_timestamps(0, None)
-                    for neo_io in self.neo_io
-                ]
-            )
+        else:
+            self.timestamps = concatenate_systime(self.neo_io)
 
         logger.info("Reading timestamps COMPLETE")
         is_timestamps_sequential = np.all(np.diff(self.timestamps))

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -47,6 +47,7 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         interpolate_dropped_packets: bool = False,
         timestamps=None,  # Use this if you already have timestamps from intializing another rec iterator on the same files
         behavior_only: bool = False,
+        include_multiplexed: bool = True,
         **kwargs,
     ):
         """
@@ -71,6 +72,12 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             timestamps to use. Can provide efficiency improvements by skipping recalculating timestamps from rec files, by default None
         behavior_only : bool, optional
             indicate if file contains only behavior data (no e-phys), by default False
+        include_multiplexed : bool, optional
+            for analog ``ECU_analog`` streams, whether to append the sample-and-held
+            multiplexed headstage channels to each read (the legacy combined-stream
+            layout). When False, only the physical ECU analog channels are read and
+            the whole-file multiplexed array is never materialized. Has no effect on
+            non-analog streams. By default True.
         kwargs : dict
             additional arguments to pass to GenericDataChunkIterator
         """
@@ -79,6 +86,7 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         logger = logging.getLogger("convert")
         self.conversion = conversion
         self.is_analog = is_analog
+        self.include_multiplexed = include_multiplexed
         self.neo_io = [
             SpikeGadgetsRawIO(
                 filename=file, interpolate_dropped_packets=interpolate_dropped_packets
@@ -142,7 +150,7 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             stream_index=self.stream_index
         )
         self.n_multiplexed_channel = 0
-        if self.is_analog:
+        if self.is_analog and self.include_multiplexed:
             self.n_multiplexed_channel += len(self.neo_io[0].multiplexed_channel_xml)
 
         # order that the hw channels are in within the nwb table
@@ -198,6 +206,9 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 self.neo_io.pop(iterator_loc)
                 self.neo_io[iterator_loc:iterator_loc] = sub_iterators
         logger.info(f"# iterators: {len(self.neo_io)}")
+        # propagate the multiplexed-append policy to every (possibly split) reader
+        for neo_io in self.neo_io:
+            neo_io._include_analog_multiplexed = self.include_multiplexed
         # NOTE: this will read all the timestamps from the rec file, which can be slow
         if timestamps is not None:
             self.timestamps = timestamps
@@ -299,9 +310,13 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         data = (np.concatenate(data) * self.conversion).astype("int16")
         # Handle the appended multiplex data
         if (
-            self.neo_io[0].header["signal_streams"][self.stream_index]["id"]
-            == "ECU_analog"
-        ) and self.is_analog:
+            (
+                self.neo_io[0].header["signal_streams"][self.stream_index]["id"]
+                == "ECU_analog"
+            )
+            and self.is_analog
+            and self.include_multiplexed
+        ):
             multiplex_keys = self.neo_io[0].multiplexed_channel_xml.keys()
             n_multiplex = len(multiplex_keys)
             n_analog = (

--- a/src/trodes_to_nwb/nwb_schema.json
+++ b/src/trodes_to_nwb/nwb_schema.json
@@ -668,13 +668,13 @@
                 "accelerometer": {
                     "type": "string",
                     "examples": [
-                        "g"
+                        "m/s^2"
                     ]
                 },
                 "gyroscope": {
                     "type": "string",
                     "examples": [
-                        "d/s"
+                        "rad/s"
                     ]
                 },
                 "magnetometer": {

--- a/src/trodes_to_nwb/nwb_schema.json
+++ b/src/trodes_to_nwb/nwb_schema.json
@@ -688,6 +688,12 @@
                     "examples": [
                         "unspecified"
                     ]
+                },
+                "analog_output": {
+                    "type": "string",
+                    "examples": [
+                        "unspecified"
+                    ]
                 }
             }
         },

--- a/src/trodes_to_nwb/nwb_schema.json
+++ b/src/trodes_to_nwb/nwb_schema.json
@@ -656,6 +656,41 @@
                 }
             }
         },
+        "sensor_units": {
+            "$id": "#root/sensor_units",
+            "title": "sensor_units",
+            "type": "object",
+            "description": "Optional per-sensor-type unit-label overrides for analog acquisition TimeSeries. Each value overrides only the unit label, not the numeric conversion factor.",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "properties": {
+                "accelerometer": {
+                    "type": "string",
+                    "examples": [
+                        "g"
+                    ]
+                },
+                "gyroscope": {
+                    "type": "string",
+                    "examples": [
+                        "d/s"
+                    ]
+                },
+                "magnetometer": {
+                    "type": "string",
+                    "examples": [
+                        "unspecified"
+                    ]
+                },
+                "analog_input": {
+                    "type": "string",
+                    "examples": [
+                        "unspecified"
+                    ]
+                }
+            }
+        },
         "times_period_multiplier": {
             "$id": "#root/times_period_multiplier",
             "title": "times_period_multiplier",

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -33,6 +33,13 @@ class SpikeGadgetsRawIO(BaseRawIO):
     extensions = ["rec"]
     rawmode = "one-file"
 
+    # When True, ``_get_analogsignal_chunk`` appends the sample-and-held
+    # multiplexed headstage channels to every ``ECU_analog`` read (the legacy
+    # combined-stream layout). Reading any ECU chunk then materializes the whole
+    # multiplexed array (see ``get_analogsignal_multiplexed``). Callers that only
+    # want the physical ECU channels set this False to avoid that allocation.
+    _include_analog_multiplexed = True
+
     def __init__(
         self,
         filename: str = "",
@@ -617,7 +624,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
         if re_order is not None:
             raw_unit16 = raw_unit16[:, re_order]
 
-        if stream_id == "ECU_analog":
+        if stream_id == "ECU_analog" and self._include_analog_multiplexed:
             # automatically include the interleaved analog signals:
             analog_multiplexed_data = self.get_analogsignal_multiplexed()[
                 i_start:i_stop, :
@@ -735,7 +742,6 @@ class SpikeGadgetsRawIO(BaseRawIO):
         ValueError
             If any specified `channel_names` are not found in the file.
         """
-        print("compute multiplex cache", self.filename)
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())
@@ -785,6 +791,52 @@ class SpikeGadgetsRawIO(BaseRawIO):
                 initialize_stream_mask[i], data[i], analog_multiplexed_data[i - 1]
             )
         return analog_multiplexed_data
+
+    def group_multiplexed_channels_by_schedule(
+        self, channel_names: list[str]
+    ) -> list[list[str]]:
+        """Partition channels by their per-channel multiplexed update schedule.
+
+        Each multiplexed channel refreshes on the packets where its own
+        ``(interleavedDataIDByte, interleavedDataIDBit)`` flag is set; channels
+        that share that pair are sampled together and form one true-rate stream.
+        Channels of one sensor (e.g. accelerometer X/Y/Z) usually share a pair,
+        but the format does not guarantee it, so callers must group before calling
+        :meth:`get_analogsignal_multiplexed_decimated` (which requires a single
+        shared schedule) rather than assume one sensor equals one schedule.
+
+        Parameters
+        ----------
+        channel_names : list of str
+            Multiplexed channel names to partition.
+
+        Returns
+        -------
+        list of list of str
+            Groups of channel names sharing an update schedule, each preserving
+            the order channels appear in ``channel_names``. The groups themselves
+            are ordered by first appearance.
+
+        Raises
+        ------
+        ValueError
+            If a channel is not present in this file's multiplexed channels.
+        """
+        groups: dict[tuple[int, int], list[str]] = {}
+        order: list[tuple[int, int]] = []
+        for name in channel_names:
+            if name not in self.multiplexed_channel_xml:
+                raise ValueError(f"Channel name '{name}' not found in file.")
+            attrib = self.multiplexed_channel_xml[name].attrib
+            key = (
+                int(attrib["interleavedDataIDByte"]),
+                int(attrib["interleavedDataIDBit"]),
+            )
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(name)
+        return [groups[key] for key in order]
 
     def get_analogsignal_multiplexed_decimated(
         self, channel_names: list[str]
@@ -908,7 +960,6 @@ class SpikeGadgetsRawIO(BaseRawIO):
         ValueError
             _description_
         """
-        print("compute multiplex cache", self.filename)
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())
@@ -1356,7 +1407,6 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         Overide of the superclass to use the last state of the previous file segment
         to define the first state of the current file segment.
         """
-        print("compute multiplex cache", self.filename)
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -842,10 +842,13 @@ class SpikeGadgetsRawIO(BaseRawIO):
             )
             data_offsets[j, 2] = int(ch_xml.attrib["interleavedDataIDBit"])
 
-        # per-packet, per-channel update flags
+        # per-packet, per-channel update flags. Cast the shift amount to uint8 so
+        # the mask stays uint8 instead of upcasting to int64 (8x the memory) across
+        # all packets -- the dominant allocation for long sessions.
+        bit_positions = data_offsets[:, 2].astype(np.uint8)
         update = (
-            (self._raw_memmap[:, data_offsets[:, 1]] >> data_offsets[:, 2]) & 1
-        ) == 1
+            (self._raw_memmap[:, data_offsets[:, 1]] >> bit_positions) & 1
+        ).astype(bool)
         # channels of one sensor are sampled together; require a shared schedule
         common = update[:, 0]
         if not np.all(update == common[:, None]):
@@ -860,10 +863,16 @@ class SpikeGadgetsRawIO(BaseRawIO):
                 update_indices,
             )
 
-        rows = self._raw_memmap[update_indices]
-        data = rows[:, data_offsets[:, 0]].astype(np.int16) + (
-            rows[:, data_offsets[:, 0] + 1].astype(np.int16) * INT_16_CONVERSION
+        # Select only the data byte-columns at the update packets, rather than
+        # copying whole packet rows (each ~hundreds of bytes); the row copy would
+        # scale with the full packet width and reach GBs on long, high-channel runs.
+        low = self._raw_memmap[np.ix_(update_indices, data_offsets[:, 0])].astype(
+            np.int16
         )
+        high = self._raw_memmap[np.ix_(update_indices, data_offsets[:, 0] + 1)].astype(
+            np.int16
+        )
+        data = low + high * INT_16_CONVERSION
         return data, update_indices
 
     def get_analogsignal_multiplexed_partial(

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -11,7 +11,6 @@ Intended as a temporary solution until official support is available in Neo.
 import functools
 from xml.etree import ElementTree
 
-import numpy as np
 from neo.rawio.baserawio import (  # TODO the import location was updated for this notebook
     BaseRawIO,
     _event_channel_dtype,
@@ -19,6 +18,7 @@ from neo.rawio.baserawio import (  # TODO the import location was updated for th
     _signal_stream_dtype,
     _spike_channel_dtype,
 )
+import numpy as np
 from scipy.stats import linregress
 
 INT_16_CONVERSION = 256
@@ -785,6 +785,81 @@ class SpikeGadgetsRawIO(BaseRawIO):
                 initialize_stream_mask[i], data[i], analog_multiplexed_data[i - 1]
             )
         return analog_multiplexed_data
+
+    def get_analogsignal_multiplexed_decimated(
+        self, channel_names: list[str]
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return only the genuinely-sampled values for a group of multiplexed channels.
+
+        Multiplexed headstage sensor data is transmitted at the sensor's true rate
+        (e.g. ~100 Hz for the IMU) and expanded to the full acquisition rate by
+        sample-and-hold in the ``.rec`` stream. This method removes the held
+        repeats using the per-packet ``interleavedDataIDBit`` flags (the same flags
+        :meth:`get_analogsignal_multiplexed` uses to decide when to refresh), so the
+        returned data is at the sensor's native rate.
+
+        All requested channels must share an identical update schedule (i.e. belong
+        to the same sensor, such as accelerometer X/Y/Z); they are sampled together.
+
+        Parameters
+        ----------
+        channel_names : list of str
+            Multiplexed channel names belonging to a single sensor.
+
+        Returns
+        -------
+        data : np.ndarray, shape (n_updates, n_channels), int16
+            The genuinely-sampled values, sample-and-hold repeats removed.
+        update_indices : np.ndarray, shape (n_updates,), int
+            Packet indices (into this file's stream) at which each sample was
+            acquired, for deriving timestamps. Empty if the channels never update
+            (e.g. a disabled sensor).
+
+        Raises
+        ------
+        ValueError
+            If a channel is not found, or the requested channels do not share an
+            identical update schedule (i.e. they belong to different sensors).
+        """
+        for ch_name in channel_names:
+            if ch_name not in self.multiplexed_channel_xml:
+                raise ValueError(f"Channel name '{ch_name}' not found in file.")
+
+        data_offsets = np.empty((len(channel_names), 3), dtype=int)
+        for j, ch_name in enumerate(channel_names):
+            ch_xml = self.multiplexed_channel_xml[ch_name]
+            data_offsets[j, 0] = int(
+                self._multiplexed_byte_start + int(ch_xml.attrib["startByte"])
+            )
+            data_offsets[j, 1] = int(
+                self._multiplexed_byte_start
+                + int(ch_xml.attrib["interleavedDataIDByte"])
+            )
+            data_offsets[j, 2] = int(ch_xml.attrib["interleavedDataIDBit"])
+
+        # per-packet, per-channel update flags
+        update = (
+            (self._raw_memmap[:, data_offsets[:, 1]] >> data_offsets[:, 2]) & 1
+        ) == 1
+        # channels of one sensor are sampled together; require a shared schedule
+        common = update[:, 0]
+        if not np.all(update == common[:, None]):
+            raise ValueError(
+                "Multiplexed channels do not share an update schedule; pass the "
+                "channels of a single sensor (e.g. accelerometer X/Y/Z)."
+            )
+        update_indices = np.flatnonzero(common)
+        if update_indices.size == 0:
+            return (
+                np.empty((0, len(channel_names)), dtype=np.int16),
+                update_indices,
+            )
+
+        rows = self._raw_memmap[update_indices]
+        data = rows[:, data_offsets[:, 0]].astype(np.int16) + (
+            rows[:, data_offsets[:, 0] + 1].astype(np.int16) * INT_16_CONVERSION
+        )
+        return data, update_indices
 
     def get_analogsignal_multiplexed_partial(
         self,

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -1360,6 +1360,7 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         self._mask_channels_bits = full_io._mask_channels_bits
         self.multiplexed_channel_xml = full_io.multiplexed_channel_xml
         self._multiplexed_byte_start = full_io._multiplexed_byte_start
+        self._include_analog_multiplexed = full_io._include_analog_multiplexed
         self._mask_streams = full_io._mask_streams
         self.selected_streams = full_io.selected_streams
         self._generate_minimal_annotations()

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -801,6 +801,11 @@ class SpikeGadgetsRawIO(BaseRawIO):
         All requested channels must share an identical update schedule (i.e. belong
         to the same sensor, such as accelerometer X/Y/Z); they are sampled together.
 
+        Unlike :meth:`get_analogsignal_multiplexed`, this method does NOT synthesize
+        a sample at packet 0: only packets whose update flag is set are returned, so
+        the first returned sample is the first genuine acquisition (the held method
+        seeds packet 0 with a possibly-stale value to start the sample-and-hold).
+
         Parameters
         ----------
         channel_names : list of str

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -241,14 +241,16 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
                     == old_analog.data[:analog_size, old_col]
                 ).all()
 
-        # headstage IMU sensors decimated to their true rate carry physical units
+        # headstage IMU sensors decimated to their true rate carry SI units
         if "accelerometer" in nwbfile.acquisition:
             accel = nwbfile.acquisition["accelerometer"]
-            assert accel.unit == "g" and accel.conversion == 0.000061
+            assert accel.unit == "m/s^2"
+            assert np.isclose(accel.conversion, 0.000061 * 9.80665)
             assert accel.data.shape[0] < analog_size  # decimated, not held full-rate
         if "gyroscope" in nwbfile.acquisition:
             gyro = nwbfile.acquisition["gyroscope"]
-            assert gyro.unit == "d/s" and gyro.conversion == 0.061
+            assert gyro.unit == "rad/s"
+            assert np.isclose(gyro.conversion, 0.061 * np.pi / 180)
 
     # compare dio data
     for dio_name in old_nwbfile.processing["behavior"]["behavioral_events"].time_series:

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -140,6 +140,7 @@ def check_module_entries(test, reference):
     todo = [
         "camera_sample_frame_counts",
         # "video_files",
+        "analog",  # moved from processing to per-sensor acquisition TimeSeries
     ]  # TODO: known missing entries
     for entry in reference:
         if entry in todo:
@@ -205,40 +206,44 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
         atol=1.0 / 30000,
     )
 
-    # check analog data
-    # get index mapping of channels
-    id_order = nwbfile.processing["analog"]["analog"]["analog"].description.split(
-        "   "
-    )[:-1]
-    old_id_order = old_nwbfile.processing["analog"]["analog"][
-        "analog"
-    ].description.split("   ")[:-1]
-    # TODO check that all the same channels are present
+    # check analog data. Analog now lives as per-sensor TimeSeries in
+    # acquisition; the rec_to_nwb reference still stores a single combined
+    # processing["analog"] stream, so recombine the new per-sensor raw int16
+    # columns by channel name and compare against the reference, per channel.
+    old_analog = old_nwbfile.processing["analog"]["analog"]["analog"]
     if (
-        old_nwbfile.processing["analog"]["analog"]["analog"].data.size > 0
+        old_analog.data.size > 0
     ):  # analog data not included in all old files. Shouldn't fail because we include it now
-        # compare analog data on channels present in rec conversion
-        if "timestamps" in old_id_order:
-            old_id_order.remove("timestamps")
-        index_order = [id_order.index(id) for id in old_id_order]
+        sensor_stream_names = {
+            "accelerometer",
+            "gyroscope",
+            "magnetometer",
+            "analog_input",
+            "other",
+        }
+        new_by_channel = {}
+        for name, ts in nwbfile.acquisition.items():
+            if name not in sensor_stream_names:
+                continue
+            channel_names = ts.description.split(": ", 1)[1].split(", ")
+            for col, channel in enumerate(channel_names):
+                new_by_channel[channel] = ts.data[:, col]
 
-        assert (
-            nwbfile.processing["analog"]["analog"]["analog"].data.shape[0]
-            == old_nwbfile.processing["analog"]["analog"]["analog"].data.shape[0]
-        ) or truncated_size
-        analog_size = nwbfile.processing["analog"]["analog"]["analog"].data.shape[0]
-        # compare matching for first timepoint
-        assert (
-            nwbfile.processing["analog"]["analog"]["analog"].data[0, :][index_order]
-            == old_nwbfile.processing["analog"]["analog"]["analog"].data[0, :]
-        ).all()
-        # compare one channel across all timepoints
-        assert (
-            nwbfile.processing["analog"]["analog"]["analog"].data[:, index_order[0]]
-            == old_nwbfile.processing["analog"]["analog"]["analog"].data[
-                :analog_size, 0
-            ]
-        ).all()
+        old_full_order = old_analog.description.split("   ")[:-1]
+        expected_channels = {ch for ch in old_full_order if ch != "timestamps"}
+        # the same analog channels are present after the move
+        assert set(new_by_channel) == expected_channels
+
+        analog_size = len(next(iter(new_by_channel.values())))
+        assert (analog_size == old_analog.data.shape[0]) or truncated_size
+        # raw int16 values match the reference, per channel, across all timepoints
+        for old_col, channel in enumerate(old_full_order):
+            if channel == "timestamps":
+                continue
+            assert (
+                new_by_channel[channel][:analog_size]
+                == old_analog.data[:analog_size, old_col]
+            ).all()
 
     # compare dio data
     for dio_name in old_nwbfile.processing["behavior"]["behavioral_events"].time_series:

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -1,12 +1,10 @@
 import os
-import shutil
 from pathlib import Path
-from unittest.mock import patch
+import shutil
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from pynwb import NWBHDF5IO
-
-from unittest.mock import MagicMock
 
 from trodes_to_nwb.convert import (
     check_file_timing,
@@ -208,42 +206,49 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
 
     # check analog data. Analog now lives as per-sensor TimeSeries in
     # acquisition; the rec_to_nwb reference still stores a single combined
-    # processing["analog"] stream, so recombine the new per-sensor raw int16
-    # columns by channel name and compare against the reference, per channel.
+    # processing["analog"] stream. ECU analog inputs stay at the full acquisition
+    # rate and must match the reference channel-for-channel. Headstage IMU sensors
+    # are decimated to their true ~100 Hz rate, so they are checked separately
+    # (presence + units), not against the 30 kHz held reference.
     old_analog = old_nwbfile.processing["analog"]["analog"]["analog"]
     if (
         old_analog.data.size > 0
     ):  # analog data not included in all old files. Shouldn't fail because we include it now
-        sensor_stream_names = {
-            "accelerometer",
-            "gyroscope",
-            "magnetometer",
-            "analog_input",
-            "other",
-        }
+        imu_names = {"accelerometer", "gyroscope", "magnetometer"}
+        # full-rate ECU streams: recombine raw int16 columns by channel name.
+        # Skip the ephys series and the decimated IMU (different timebases); analog
+        # streams encode their channel list in the description as "<desc>: a, b, c".
         new_by_channel = {}
         for name, ts in nwbfile.acquisition.items():
-            if name not in sensor_stream_names:
+            if name == "e-series" or name in imu_names or ": " not in ts.description:
                 continue
             channel_names = ts.description.split(": ", 1)[1].split(", ")
             for col, channel in enumerate(channel_names):
                 new_by_channel[channel] = ts.data[:, col]
 
         old_full_order = old_analog.description.split("   ")[:-1]
-        expected_channels = {ch for ch in old_full_order if ch != "timestamps"}
-        # the same analog channels are present after the move
-        assert set(new_by_channel) == expected_channels
-
-        analog_size = len(next(iter(new_by_channel.values())))
+        ecu_channels = [
+            ch for ch in old_full_order if ch != "timestamps" and ch in new_by_channel
+        ]
+        assert ecu_channels  # at least the ECU analog inputs are present
+        analog_size = len(new_by_channel[ecu_channels[0]])
         assert (analog_size == old_analog.data.shape[0]) or truncated_size
-        # raw int16 values match the reference, per channel, across all timepoints
+        # raw int16 values match the reference, per ECU channel, across all timepoints
         for old_col, channel in enumerate(old_full_order):
-            if channel == "timestamps":
-                continue
-            assert (
-                new_by_channel[channel][:analog_size]
-                == old_analog.data[:analog_size, old_col]
-            ).all()
+            if channel in new_by_channel:
+                assert (
+                    new_by_channel[channel][:analog_size]
+                    == old_analog.data[:analog_size, old_col]
+                ).all()
+
+        # headstage IMU sensors decimated to their true rate carry physical units
+        if "accelerometer" in nwbfile.acquisition:
+            accel = nwbfile.acquisition["accelerometer"]
+            assert accel.unit == "g" and accel.conversion == 0.000061
+            assert accel.data.shape[0] < analog_size  # decimated, not held full-rate
+        if "gyroscope" in nwbfile.acquisition:
+            gyro = nwbfile.acquisition["gyroscope"]
+            assert gyro.unit == "d/s" and gyro.conversion == 0.061
 
     # compare dio data
     for dio_name in old_nwbfile.processing["behavior"]["behavioral_events"].time_series:

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -241,13 +241,17 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
                     == old_analog.data[:analog_size, old_col]
                 ).all()
 
-        # headstage IMU sensors decimated to their true rate carry SI units
-        if "accelerometer" in nwbfile.acquisition:
+        # headstage IMU sensors decimated to their true rate carry SI units. Tie
+        # presence to the reference so a regression that drops a sensor entirely
+        # fails here rather than passing vacuously.
+        if any(c.startswith("Headstage_Accel") for c in old_full_order):
+            assert "accelerometer" in nwbfile.acquisition
             accel = nwbfile.acquisition["accelerometer"]
             assert accel.unit == "m/s^2"
             assert np.isclose(accel.conversion, 0.000061 * 9.80665)
             assert accel.data.shape[0] < analog_size  # decimated, not held full-rate
-        if "gyroscope" in nwbfile.acquisition:
+        if any(c.startswith("Headstage_Gyro") for c in old_full_order):
+            assert "gyroscope" in nwbfile.acquisition
             gyro = nwbfile.acquisition["gyroscope"]
             assert gyro.unit == "rad/s"
             assert np.isclose(gyro.conversion, 0.061 * np.pi / 180)

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -33,11 +33,17 @@ class _FakeNeoIO:
     ``decimated`` maps a tuple of channel names (one sensor group) to the
     ``(data, update_indices)`` that ``get_analogsignal_multiplexed_decimated``
     should return. Groups not present are treated as disabled (no samples).
+
+    ``schedule`` optionally maps each channel name to its
+    ``(interleavedDataIDByte, interleavedDataIDBit)`` pair, used by
+    ``group_multiplexed_channels_by_schedule``. When omitted, all channels are
+    treated as sharing one schedule (a single group), matching the common case.
     """
 
-    def __init__(self, multiplexed_ids, decimated):
+    def __init__(self, multiplexed_ids, decimated, schedule=None):
         self.multiplexed_channel_xml = dict.fromkeys(multiplexed_ids)
         self._decimated = decimated
+        self._schedule = schedule
 
     def get_analogsignal_multiplexed_decimated(self, channel_names):
         key = tuple(channel_names)
@@ -46,6 +52,18 @@ class _FakeNeoIO:
         return np.empty((0, len(channel_names)), dtype=np.int16), np.array(
             [], dtype=int
         )
+
+    def group_multiplexed_channels_by_schedule(self, channel_names):
+        if self._schedule is None:
+            return [list(channel_names)]
+        groups, order = {}, []
+        for name in channel_names:
+            key = self._schedule[name]
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(name)
+        return [groups[key] for key in order]
 
 
 class _FakeRecDCI:
@@ -58,11 +76,13 @@ class _FakeRecDCI:
     plus ``timestamps``, ``n_time``, ``neo_io``, ``maxshape`` and ``_get_data``.
     """
 
-    def __init__(self, combined_data, multiplexed_ids, timestamps, decimated=None):
+    def __init__(
+        self, combined_data, multiplexed_ids, timestamps, decimated=None, schedule=None
+    ):
         self._data = combined_data
         self.timestamps = timestamps
         self.n_time = [combined_data.shape[0]]
-        self.neo_io = [_FakeNeoIO(multiplexed_ids, decimated or {})]
+        self.neo_io = [_FakeNeoIO(multiplexed_ids, decimated or {}, schedule=schedule)]
 
     @property
     def maxshape(self):
@@ -84,15 +104,34 @@ def _make_minimal_nwbfile():
 
 
 def _patch_analog_source(
-    monkeypatch, ecu_ids, multiplexed_ids, combined_data, timestamps, decimated=None
+    monkeypatch,
+    ecu_ids,
+    multiplexed_ids,
+    combined_data,
+    timestamps,
+    decimated=None,
+    schedule=None,
 ):
-    """Patch add_analog_data's rec-file reads to serve synthetic data."""
+    """Patch add_analog_data's rec-file reads to serve synthetic data.
+
+    Patches both seams so the same harness works whether or not ECU analog
+    channels are present: ``RecFileDataChunkIterator`` (ECU path) and
+    ``_open_headstage_only_sources`` (no-ECU path) both resolve to the same
+    synthetic ``_FakeRecDCI``.
+    """
     monkeypatch.setattr(
         convert_analog, "_get_ecu_analog_channel_ids", lambda path: list(ecu_ids)
     )
-    fake = _FakeRecDCI(combined_data, multiplexed_ids, timestamps, decimated)
+    fake = _FakeRecDCI(
+        combined_data, multiplexed_ids, timestamps, decimated, schedule=schedule
+    )
     monkeypatch.setattr(
         convert_analog, "RecFileDataChunkIterator", lambda *a, **k: fake
+    )
+    monkeypatch.setattr(
+        convert_analog,
+        "_open_headstage_only_sources",
+        lambda paths, ts: (fake.neo_io, fake.n_time, fake.timestamps),
     )
     return fake
 
@@ -304,8 +343,11 @@ def test_add_analog_data_multifile_decimation_synthetic(monkeypatch):
     fake = _MultiFileRecDCI()
     fake.timestamps = timestamps
     monkeypatch.setattr(convert_analog, "_get_ecu_analog_channel_ids", lambda path: [])
+    # no ECU channels -> headstage-only path; serve the synthetic readers directly
     monkeypatch.setattr(
-        convert_analog, "RecFileDataChunkIterator", lambda *a, **k: fake
+        convert_analog,
+        "_open_headstage_only_sources",
+        lambda paths, ts: (fake.neo_io, fake.n_time, fake.timestamps),
     )
 
     nwbfile = _make_minimal_nwbfile()
@@ -479,6 +521,170 @@ def test_get_decimated_multiplexed_real_data():
         io.get_analogsignal_multiplexed_decimated(
             ["Headstage_AccelX", "Headstage_GyroX"]
         )
+
+
+def test_group_multiplexed_channels_by_schedule_real_data():
+    """Co-scheduled axes group together; different sensors split into groups."""
+    io = SpikeGadgetsRawIO(filename=str(data_path / "20230622_sample_01_a1.rec"))
+    io.parse_header()
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    # all accel axes share (interleavedDataIDByte, Bit) -> a single group
+    assert io.group_multiplexed_channels_by_schedule(accel) == [accel]
+    # accel and gyro update on different bits -> two groups, input order preserved
+    assert io.group_multiplexed_channels_by_schedule(
+        ["Headstage_AccelX", "Headstage_GyroX"]
+    ) == [["Headstage_AccelX"], ["Headstage_GyroX"]]
+
+
+def test_get_ecu_analog_channel_ids_no_ecu_returns_empty(monkeypatch):
+    """A recording with no ECU device yields [] instead of raising on None."""
+    from xml.etree import ElementTree as ET
+
+    root = ET.fromstring(
+        "<Configuration><HardwareConfiguration>"
+        '<Device name="headstageSensor">'
+        '<Channel id="AccelX" dataType="analog" startByte="2"'
+        ' interleavedDataIDByte="0" interleavedDataIDBit="3"/>'
+        "</Device>"
+        "</HardwareConfiguration></Configuration>"
+    )
+    monkeypatch.setattr(
+        convert_analog.convert_rec_header, "read_header", lambda path: root
+    )
+    assert convert_analog._get_ecu_analog_channel_ids("nonexistent.rec") == []
+
+
+def test_get_analog_channel_names_no_ecu_returns_empty():
+    """The public helper is consistent with _get_ecu_analog_channel_ids on no-ECU."""
+    from xml.etree import ElementTree as ET
+
+    header = ET.fromstring(
+        "<Configuration><HardwareConfiguration>"
+        '<Device name="headstageSensor">'
+        '<Channel id="AccelX" dataType="analog" startByte="2"'
+        ' interleavedDataIDByte="0" interleavedDataIDBit="3"/>'
+        "</Device>"
+        "</HardwareConfiguration></Configuration>"
+    )
+    assert convert_analog.get_analog_channel_names(header) == []
+
+
+def test_ecu_read_does_not_materialize_multiplexed():
+    """Reading the physical ECU columns must never build the multiplexed array.
+
+    This is the memory regression guard: with include_multiplexed=False the whole
+    -file sample-and-held multiplexed array (get_analogsignal_multiplexed) must not
+    be touched when materializing the ECU acquisition streams.
+    """
+    rec = str(data_path / "20230622_sample_01_a1.rec")
+    ecu_ids = convert_analog._get_ecu_analog_channel_ids(rec)
+    rec_dci = RecFileDataChunkIterator(
+        [rec],
+        nwb_hw_channel_order=ecu_ids,
+        stream_id="ECU_analog",
+        is_analog=True,
+        include_multiplexed=False,
+    )
+    # the iterator exposes only the physical ECU columns (no appended multiplexed)
+    assert rec_dci.maxshape[1] == len(ecu_ids)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("get_analogsignal_multiplexed was materialized")
+
+    for io in rec_dci.neo_io:
+        io.get_analogsignal_multiplexed = _boom
+    subset = convert_analog._AnalogChannelSubsetIterator(
+        rec_dci, list(range(len(ecu_ids)))
+    )
+    materialized = _materialize(subset)  # full read of all ECU columns
+    assert materialized.shape == (rec_dci.maxshape[0], len(ecu_ids))
+
+
+def test_include_multiplexed_true_appends_mux_columns():
+    """The legacy default still appends the multiplexed channels (combined layout)."""
+    rec = str(data_path / "20230622_sample_01_a1.rec")
+    ecu_ids = convert_analog._get_ecu_analog_channel_ids(rec)
+    rec_dci = RecFileDataChunkIterator(
+        [rec],
+        nwb_hw_channel_order=ecu_ids,
+        stream_id="ECU_analog",
+        is_analog=True,
+    )
+    n_mux = len(rec_dci.neo_io[0].multiplexed_channel_xml)
+    assert n_mux > 0
+    assert rec_dci.maxshape[1] == len(ecu_ids) + n_mux
+
+
+def test_no_ecu_headstage_only_writes_streams(monkeypatch):
+    """Headstage-only recordings (no ECU) still write the decimated sensor streams."""
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    gyro = ["Headstage_GyroX", "Headstage_GyroY", "Headstage_GyroZ"]
+    mux_ids = accel + gyro
+    n_time = 60
+    combined = np.zeros((n_time, 0), dtype=np.int16)  # no ECU columns
+    timestamps = np.arange(n_time, dtype=float)
+    accel_data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int16)
+    gyro_data = np.array([[7, 8, 9]], dtype=np.int16)
+    decimated = {
+        tuple(accel): (accel_data, np.array([10, 30])),
+        tuple(gyro): (gyro_data, np.array([20])),
+    }
+    _patch_analog_source(monkeypatch, [], mux_ids, combined, timestamps, decimated)
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["headstage_only.rec"])
+
+    # no ECU streams, but both IMU sensors are written with their own timebases
+    assert "analog_input" not in nwbfile.acquisition
+    assert (nwbfile.acquisition["accelerometer"].data[:] == accel_data).all()
+    assert (
+        nwbfile.acquisition["accelerometer"].timestamps[:] == timestamps[[10, 30]]
+    ).all()
+    assert (nwbfile.acquisition["gyroscope"].data[:] == gyro_data).all()
+    assert (nwbfile.acquisition["gyroscope"].timestamps[:] == timestamps[[20]]).all()
+
+
+def test_mixed_update_schedule_splits_into_streams(monkeypatch):
+    """A sensor whose axes update on different schedules splits into separate streams.
+
+    Rather than raising (the reader requires one shared schedule per call), the
+    channels are partitioned by (interleavedDataIDByte, interleavedDataIDBit) and
+    each co-sampled group is written as its own acquisition TimeSeries.
+    """
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    n_time = 40
+    combined = np.zeros((n_time, 0), dtype=np.int16)
+    timestamps = np.arange(n_time, dtype=float)
+    # AccelX/Y share one schedule; AccelZ updates on a different bit
+    schedule = {
+        "Headstage_AccelX": (0, 3),
+        "Headstage_AccelY": (0, 3),
+        "Headstage_AccelZ": (0, 4),
+    }
+    xy_data = np.array([[1, 2], [3, 4]], dtype=np.int16)
+    z_data = np.array([[5], [6], [7]], dtype=np.int16)
+    decimated = {
+        ("Headstage_AccelX", "Headstage_AccelY"): (xy_data, np.array([5, 25])),
+        ("Headstage_AccelZ",): (z_data, np.array([8, 18, 28])),
+    }
+    _patch_analog_source(
+        monkeypatch, [], accel, combined, timestamps, decimated, schedule=schedule
+    )
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["headstage_only.rec"])
+
+    # two streams written (not one, and no ValueError), disambiguated by name
+    assert "accelerometer" in nwbfile.acquisition
+    assert "accelerometer_2" in nwbfile.acquisition
+    xy = nwbfile.acquisition["accelerometer"]
+    z = nwbfile.acquisition["accelerometer_2"]
+    assert (xy.data[:] == xy_data).all()
+    assert (z.data[:] == z_data).all()
+    # each group rides its own (distinct) decimated timebase
+    assert (xy.timestamps[:] == timestamps[[5, 25]]).all()
+    assert (z.timestamps[:] == timestamps[[8, 18, 28]]).all()
+    # the two groups list their own channels in the descriptions
+    assert "Headstage_AccelX, Headstage_AccelY" in xy.description
+    assert "Headstage_AccelZ" in z.description
 
 
 def test_accelerometer_conversion_recovers_gravity():
@@ -708,6 +914,7 @@ def test_categorize_all_sensor_types():
         "Headstage_MagY",
         "Headstage_MagZ",
         "ECU_Ain1",
+        "ECU_Aout1",
         "Controller_Ain2",
         "Foo_Bar",
     ]
@@ -730,8 +937,36 @@ def test_categorize_all_sensor_types():
     # ECU and controller analog inputs are distinct sensor types (different
     # sources/sampling), so "analog_input" is unambiguously the ECU stream.
     assert groups["analog_input"] == ["ECU_Ain1"]
+    assert groups["analog_output"] == ["ECU_Aout1"]
     assert groups["controller_analog_input"] == ["Controller_Ain2"]
     assert groups["other"] == ["Foo_Bar"]
+
+
+def test_categorize_accepts_bare_imu_names():
+    """Trodes' bare headstageSensor channel ids categorize like the prefixed ones."""
+    channels = [
+        "AccelX",
+        "AccelY",
+        "AccelZ",
+        "GyroX",
+        "GyroY",
+        "GyroZ",
+        "MagX",
+        "MagY",
+        "MagZ",
+    ]
+    groups = _categorize_sensor_channels(channels)
+    assert groups["accelerometer"] == ["AccelX", "AccelY", "AccelZ"]
+    assert groups["gyroscope"] == ["GyroX", "GyroY", "GyroZ"]
+    assert groups["magnetometer"] == ["MagX", "MagY", "MagZ"]
+    assert "other" not in groups
+
+
+def test_categorize_ecu_analog_output_not_other():
+    """ECU analog outputs are a known category, not warned-on 'other' channels."""
+    groups = _categorize_sensor_channels(["ECU_Aout1", "ECU_Aout2"])
+    assert groups["analog_output"] == ["ECU_Aout1", "ECU_Aout2"]
+    assert "other" not in groups
 
 
 def test_categorize_preserves_input_order():

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -10,6 +10,7 @@ from hdmf.backends.hdf5 import H5DataIO
 import numpy as np
 import pynwb
 from pynwb import NWBFile
+import pytest
 
 from trodes_to_nwb import convert_analog, convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_analog import (
@@ -17,7 +18,6 @@ from trodes_to_nwb.convert_analog import (
     _categorize_sensor_channels,
     _resolve_sensor_unit,
     add_analog_data,
-    get_analog_channel_names,
     update_analog_data,
 )
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
@@ -42,6 +42,10 @@ class _FakeRecDCI:
                 multiplexed_channel_xml=dict.fromkeys(multiplexed_ids)
             )
         ]
+
+    @property
+    def maxshape(self):
+        return self._data.shape
 
     def _get_maxshape(self):
         return self._data.shape
@@ -262,6 +266,143 @@ def test_analog_subset_iterator_parity():
     assert (_materialize(iterator) == data[:, columns]).all()
 
 
+def test_analog_subset_iterator_rejects_bad_columns():
+    """Out-of-range column indices fail loudly at construction."""
+    data = np.zeros((10, 3), dtype=np.int16)
+    fake = _FakeRecDCI(data, [], np.arange(10, dtype=float))
+    with pytest.raises(ValueError, match="out of range"):
+        convert_analog._AnalogChannelSubsetIterator(fake, [0, 5])
+
+
+def test_add_analog_data_no_channels_returns(monkeypatch, caplog):
+    """No analog channels: logs and returns without adding acquisitions."""
+    combined = np.zeros((5, 0), dtype=np.int16)
+    _patch_analog_source(monkeypatch, [], [], combined, np.arange(5, dtype=float))
+    nwbfile = _make_minimal_nwbfile()
+    with caplog.at_level(logging.INFO, logger="convert"):
+        add_analog_data(nwbfile, ["fake.rec"])
+    assert len(nwbfile.acquisition) == 0
+    assert "No analog channels found" in caplog.text
+
+
+def test_magnetometer_and_other_units(monkeypatch):
+    """Magnetometer and 'other' streams carry conversion 1.0 / unit 'unspecified'."""
+    ecu_ids = ["Mystery_Chan"]
+    mux_ids = ["Headstage_MagX", "Headstage_MagY", "Headstage_MagZ"]
+    combined = np.zeros((10, len(ecu_ids) + len(mux_ids)), dtype=np.int16)
+    _patch_analog_source(
+        monkeypatch, ecu_ids, mux_ids, combined, np.arange(10, dtype=float)
+    )
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["fake.rec"])
+    for name in ("magnetometer", "other"):
+        assert nwbfile.acquisition[name].conversion == 1.0
+        assert nwbfile.acquisition[name].unit == "unspecified"
+
+
+def test_sensor_streams_share_one_timestamps(monkeypatch):
+    """Streams after the first link to the first stream's timestamps (stored once)."""
+    ecu_ids = ["ECU_Ain1"]
+    mux_ids = ["Headstage_AccelX"]
+    combined = np.zeros((10, 2), dtype=np.int16)
+    _patch_analog_source(
+        monkeypatch, ecu_ids, mux_ids, combined, np.arange(10, dtype=float)
+    )
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["fake.rec"])
+    streams = list(nwbfile.acquisition.values())
+    assert len(streams) >= 2
+    # every stream resolves to the same timestamps array (stored once, linked),
+    # and at least one stream links rather than owning a second copy
+    timestamp_arrays = [ts.timestamps for ts in streams]
+    assert all(arr is timestamp_arrays[0] for arr in timestamp_arrays)
+    assert any(ts.timestamp_link for ts in streams)
+
+
+def test_unknown_sensor_units_key_warns(monkeypatch, caplog):
+    """A misspelled sensor_units key is warned about, not silently ignored."""
+    ecu_ids = ["ECU_Ain1"]
+    combined = np.zeros((5, 1), dtype=np.int16)
+    _patch_analog_source(monkeypatch, ecu_ids, [], combined, np.arange(5, dtype=float))
+    nwbfile = _make_minimal_nwbfile()
+    with caplog.at_level(logging.WARNING, logger="convert"):
+        add_analog_data(
+            nwbfile, ["fake.rec"], metadata={"sensor_units": {"accel": "g"}}
+        )
+    assert "accel" in caplog.text
+    assert "unrecognized" in caplog.text.lower()
+
+
+def test_add_analog_data_short_session_writes(monkeypatch, tmp_path):
+    """A sub-chunk-length session writes and reads back with raw int16 intact."""
+    ecu_ids = ["ECU_Ain1", "ECU_Ain2"]
+    n_time = 50  # far below DEFAULT_CHUNK_TIME_DIM
+    combined = np.arange(n_time * 2, dtype=np.int16).reshape(n_time, 2)
+    _patch_analog_source(
+        monkeypatch, ecu_ids, [], combined, np.arange(n_time, dtype=float)
+    )
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["fake.rec"])
+    path = tmp_path / "short.nwb"
+    with pynwb.NWBHDF5IO(path, "w") as io:
+        io.write(nwbfile)
+    with pynwb.NWBHDF5IO(path, "r") as io:
+        read = io.read()
+        analog_input = read.acquisition["analog_input"]
+        assert analog_input.data.shape == (n_time, 2)
+        assert (analog_input.data[:] == combined).all()
+
+
+def test_update_analog_data_rejects_new_layout(monkeypatch, tmp_path):
+    """update_analog_data fails clearly on files without the legacy analog stream."""
+    monkeypatch.setattr(convert_analog, "_get_ecu_analog_channel_ids", lambda path: [])
+    nwbfile = _make_minimal_nwbfile()
+    path = tmp_path / "new_layout.nwb"
+    with pynwb.NWBHDF5IO(path, "w") as io:
+        io.write(nwbfile)
+    with pytest.raises(ValueError, match="legacy combined analog stream"):
+        update_analog_data(str(path), ["fake.rec"])
+
+
+def _write_legacy_combined_analog(nwbfile, rec_file_path):
+    """Write the pre-sensor-separation combined analog stream.
+
+    Reproduces the legacy ``processing["analog"]["analog"]["analog"]`` layout
+    (a single combined TimeSeries with ``unit="-1"``) that production no longer
+    writes, so the legacy-repair path of ``update_analog_data`` can be tested
+    against a file in that layout.
+    """
+    analog_channel_ids = convert_analog._get_ecu_analog_channel_ids(rec_file_path[0])
+    rec_dci = RecFileDataChunkIterator(
+        rec_file_path,
+        nwb_hw_channel_order=analog_channel_ids,
+        stream_id="ECU_analog",
+        is_analog=True,
+    )
+    analog_channel_ids.extend(rec_dci.neo_io[0].multiplexed_channel_xml.keys())
+    data_io = H5DataIO(
+        rec_dci,
+        chunks=(
+            convert_analog.DEFAULT_CHUNK_TIME_DIM,
+            min(len(analog_channel_ids), convert_analog.DEFAULT_CHUNK_MAX_CHANNEL_DIM),
+        ),
+    )
+    nwbfile.create_processing_module(
+        name="analog", description="Contains all analog data"
+    )
+    analog_events = pynwb.behavior.BehavioralEvents(name="analog")
+    analog_events.add_timeseries(
+        pynwb.TimeSeries(
+            name="analog",
+            description="   ".join(analog_channel_ids) + "   ",
+            data=data_io,
+            timestamps=rec_dci.timestamps,
+            unit="-1",
+        )
+    )
+    nwbfile.processing["analog"].add(analog_events)
+
+
 def test_update_analog_data():
     """Test that update_analog_data correctly overwrites data in an existing NWB file."""
     rec_files = [
@@ -273,10 +414,9 @@ def test_update_analog_data():
     metadata, _ = convert_yaml.load_metadata(metadata_path, [])
     rec_header = convert_rec_header.read_header(rec_files[0])
 
-    # make file with data
+    # make a file in the legacy combined-analog layout that update_analog_data repairs
     nwbfile = convert_yaml.initialize_nwb(metadata, rec_header)
-    get_analog_channel_names(rec_header)
-    add_analog_data(nwbfile, rec_files)
+    _write_legacy_combined_analog(nwbfile, rec_files)
 
     # save file
     ref_filename = "correctly_added_analog.nwb"

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -261,10 +261,60 @@ def test_add_analog_data_multifile_longer_than_single(monkeypatch):
     nwb_multi = convert_yaml.initialize_nwb(metadata, rec_header)
     add_analog_data(nwb_multi, [rec1, rec2], metadata=metadata)
 
-    stream_name = next(iter(nwb_single.acquisition))
-    len_single = nwb_single.acquisition[stream_name].data.data._get_maxshape()[0]
-    len_multi = nwb_multi.acquisition[stream_name].data.data._get_maxshape()[0]
+    # ECU full-rate stream spans both files
+    ecu_name = next(
+        n for n in nwb_single.acquisition if n not in ("accelerometer", "gyroscope")
+    )
+    len_single = nwb_single.acquisition[ecu_name].data.data._get_maxshape()[0]
+    len_multi = nwb_multi.acquisition[ecu_name].data.data._get_maxshape()[0]
     assert len_multi > len_single
+    # the decimated IMU also spans both files, with timestamps strictly increasing
+    # across the file boundary (guards the file_start offset + concatenation)
+    acc_single = nwb_single.acquisition["accelerometer"]
+    acc_multi = nwb_multi.acquisition["accelerometer"]
+    assert acc_multi.data.shape[0] > acc_single.data.shape[0]
+    assert np.all(np.diff(acc_multi.timestamps[:]) > 0)
+
+
+def test_add_analog_data_multifile_decimation_synthetic(monkeypatch):
+    """Synthetic 2-file: decimated IMU concatenates with globally-offset timestamps.
+
+    The real fixtures cover this end-to-end, but the synthetic harness pins the
+    file_start offset arithmetic deterministically: per-file local update indices
+    must be mapped onto the shared (concatenated) timestamps via cumsum(n_time).
+    """
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    n0, n1 = 100, 80
+    timestamps = np.arange(n0 + n1, dtype=float) * 0.001
+    d0 = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=np.int16)
+    i0 = np.array([10, 40, 70])
+    d1 = np.array([[4, 4, 4], [5, 5, 5]], dtype=np.int16)
+    i1 = np.array([5, 35])
+
+    class _MultiFileRecDCI:
+        n_time = [n0, n1]
+        neo_io = [
+            _FakeNeoIO(accel, {tuple(accel): (d0, i0)}),
+            _FakeNeoIO(accel, {tuple(accel): (d1, i1)}),
+        ]
+
+    fake = _MultiFileRecDCI()
+    fake.timestamps = timestamps
+    monkeypatch.setattr(convert_analog, "_get_ecu_analog_channel_ids", lambda path: [])
+    monkeypatch.setattr(
+        convert_analog, "RecFileDataChunkIterator", lambda *a, **k: fake
+    )
+
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["a.rec", "b.rec"])
+
+    acc = nwbfile.acquisition["accelerometer"]
+    # data concatenated in file order
+    assert (acc.data == np.concatenate([d0, d1])).all()
+    # second file's local indices offset by n0 onto the shared timeline
+    expected_idx = np.concatenate([i0, i1 + n0])
+    assert (acc.timestamps[:] == timestamps[expected_idx]).all()
+    assert np.all(np.diff(acc.timestamps[:]) > 0)
 
 
 def test_sensor_unit_metadata_override(monkeypatch):
@@ -387,6 +437,12 @@ def test_get_decimated_multiplexed_real_data():
     data, idx = io.get_analogsignal_multiplexed_decimated(accel)
     assert data.shape == (idx.size, 3) and idx.size > 0
     assert 90.0 < 30000.0 / np.median(np.diff(idx)) < 110.0  # ~100 Hz @ 30 kHz
+    # value oracle: decimated bytes equal the trusted held method's values at the
+    # update packets (catches byte-assembly / offset regressions in the new reader)
+    held = io.get_analogsignal_multiplexed()  # (n_packet, n_mux), held full-rate
+    mux_ids = list(io.multiplexed_channel_xml.keys())
+    accel_cols = [mux_ids.index(c) for c in accel]
+    assert np.array_equal(data, held[np.ix_(idx, accel_cols)])
     # disabled sensor -> empty
     mag = ["Headstage_MagX", "Headstage_MagY", "Headstage_MagZ"]
     mag_data, mag_idx = io.get_analogsignal_multiplexed_decimated(mag)
@@ -604,7 +660,10 @@ def test_categorize_all_sensor_types():
         "Headstage_MagY",
         "Headstage_MagZ",
     ]
-    assert groups["analog_input"] == ["ECU_Ain1", "Controller_Ain2"]
+    # ECU and controller analog inputs are distinct sensor types (different
+    # sources/sampling), so "analog_input" is unambiguously the ECU stream.
+    assert groups["analog_input"] == ["ECU_Ain1"]
+    assert groups["controller_analog_input"] == ["Controller_Ain2"]
     assert groups["other"] == ["Foo_Bar"]
 
 

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -15,8 +15,10 @@ import pytest
 from trodes_to_nwb import convert_analog, convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_analog import (
     SENSOR_TYPE_CONFIG,
+    SensorConfig,
     _categorize_sensor_channels,
     _resolve_sensor_unit,
+    _unique_acquisition_name,
     add_analog_data,
     update_analog_data,
 )
@@ -157,6 +159,7 @@ def test_add_analog_data():
             for nm, ts in read_nwbfile.acquisition.items():
                 if nm in imu_names:
                     continue
+                # contract: add_analog_data writes "<description>: ch1, ch2, ..."
                 channels = ts.description.split(": ", 1)[1].split(", ")
                 for col, channel in enumerate(channels):
                     new_by_channel[channel] = ts.data[:, col]
@@ -242,7 +245,7 @@ def test_add_analog_data_stream_spans_full_source_length(monkeypatch):
     assert materialized.shape[0] == n_time
 
 
-def test_add_analog_data_multifile_longer_than_single(monkeypatch):
+def test_add_analog_data_multifile_longer_than_single():
     """Integration: a two-file conversion is strictly longer than one file.
 
     Requires downloaded .rec fixtures. Directly guards against reading only the
@@ -404,6 +407,30 @@ def test_disabled_sensor_omitted_and_logged(monkeypatch, caplog):
         add_analog_data(nwbfile, ["fake.rec"])
     assert "magnetometer" not in nwbfile.acquisition
     assert "no sampled data (disabled)" in caplog.text
+
+
+def test_controller_analog_input_is_separate_decimated_stream(monkeypatch):
+    """Controller_Ain* rides the multiplexed stream -> its own decimated stream,
+    distinct from the full-rate ECU 'analog_input'."""
+    ecu_ids = ["ECU_Ain1"]  # full-rate ECU -> "analog_input"
+    controller = ["Controller_Ain1", "Controller_Ain2"]  # multiplexed -> decimated
+    combined = np.zeros((20, len(ecu_ids) + len(controller)), dtype=np.int16)
+    ctrl_data = np.array([[7, 8], [9, 10]], dtype=np.int16)
+    ctrl_idx = np.array([3, 12])
+    decimated = {tuple(controller): (ctrl_data, ctrl_idx)}
+    timestamps = np.arange(20, dtype=float)
+    _patch_analog_source(
+        monkeypatch, ecu_ids, controller, combined, timestamps, decimated
+    )
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["fake.rec"])
+
+    assert "analog_input" in nwbfile.acquisition  # ECU, full-rate (lazy)
+    assert isinstance(nwbfile.acquisition["analog_input"].data, H5DataIO)
+    cai = nwbfile.acquisition["controller_analog_input"]  # multiplexed, decimated
+    assert isinstance(cai.data, np.ndarray)
+    assert (cai.data == ctrl_data).all()
+    assert (cai.timestamps[:] == timestamps[ctrl_idx]).all()
 
 
 def test_ecu_streams_share_timestamps_imu_independent(monkeypatch):
@@ -595,13 +622,12 @@ def _write_legacy_combined_analog(nwbfile, rec_file_path):
     nwbfile.processing["analog"].add(analog_events)
 
 
-def test_update_analog_data():
-    """Test that update_analog_data correctly overwrites data in an existing NWB file."""
+def test_update_analog_data(tmp_path):
+    """update_analog_data restores the analog data in a legacy-layout NWB file."""
     rec_files = [
         data_path / "20230622_sample_01_a1.rec",
         data_path / "20230622_sample_02_a1.rec",
     ]
-
     metadata_path = data_path / "20230622_sample_metadata.yml"
     metadata, _ = convert_yaml.load_metadata(metadata_path, [])
     rec_header = convert_rec_header.read_header(rec_files[0])
@@ -610,47 +636,31 @@ def test_update_analog_data():
     nwbfile = convert_yaml.initialize_nwb(metadata, rec_header)
     _write_legacy_combined_analog(nwbfile, rec_files)
 
-    # save file
-    ref_filename = "correctly_added_analog.nwb"
+    ref_filename = str(tmp_path / "correctly_added_analog.nwb")
     with pynwb.NWBHDF5IO(ref_filename, "w") as io:
         io.write(nwbfile)
 
-    # Copy the reference NWB file so we don't modify the original
-    buggy_filename = "test_update_analog_buggy.nwb"
+    # copy the reference and zero its analog data to simulate the pre-fix state
+    buggy_filename = str(tmp_path / "test_update_analog_buggy.nwb")
     shutil.copy(ref_filename, buggy_filename)
-
-    # Zero out the analog data in the copy to simulate the pre-fix (buggy) state
     with h5py.File(buggy_filename, "r+") as f:
         analog_hdf5_path = "processing/analog/analog/analog/data"
         f[analog_hdf5_path][...] = np.zeros_like(f[analog_hdf5_path][()])
-
-    # Confirm data was zeroed out
     with pynwb.NWBHDF5IO(buggy_filename, "r", load_namespaces=True) as io:
-        buggy_nwbfile = io.read()
-        buggy_data = buggy_nwbfile.processing["analog"]["analog"]["analog"].data[:]
+        buggy_data = io.read().processing["analog"]["analog"]["analog"].data[:]
     assert (buggy_data == 0).all(), "Buggy data should be all zeros before update"
 
-    # Run the update function (timestamps default to those already in the NWB file)
+    # run the repair (timestamps default to those already in the NWB file)
     update_analog_data(buggy_filename, rec_files)
 
-    print("buggy file name: \n", buggy_filename)
     with pynwb.NWBHDF5IO(ref_filename, "r", load_namespaces=True) as io:
-        correct_nwbfile = io.read()
-        correct_data = correct_nwbfile.processing["analog"]["analog"]["analog"].data[:]
-
+        correct_data = io.read().processing["analog"]["analog"]["analog"].data[:]
     with pynwb.NWBHDF5IO(buggy_filename, "r", load_namespaces=True) as io:
-        updated_nwbfile = io.read()
-        updated_data = updated_nwbfile.processing["analog"]["analog"]["analog"].data[:]
+        updated_data = io.read().processing["analog"]["analog"]["analog"].data[:]
 
-    # Map channel indices from the updated file into the correct file's ordering
-    assert correct_data.shape == updated_data.shape
-    # compare one non-zero multiplexed channel across all timepoints
-    test_index = 14
-    assert (correct_data[:, test_index] == updated_data[:, test_index]).all()
-
-    # cleanup
-    os.remove(buggy_filename)
-    os.remove(ref_filename)
+    # the repaired file matches the correct file on every channel and timepoint
+    assert updated_data.shape == correct_data.shape
+    assert np.array_equal(updated_data, correct_data)
 
 
 def test_selection_of_multiplexed_data():
@@ -775,6 +785,44 @@ def test_sensor_config_conversion_unit_consistency():
 def test_sensor_config_is_immutable():
     with pytest.raises(FrozenInstanceError):
         SENSOR_TYPE_CONFIG["accelerometer"].conversion = 1.0
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"conversion": 0.0},
+        {"conversion": float("nan")},
+        {"conversion": float("inf")},
+        {"unit": ""},
+    ],
+)
+def test_sensor_config_rejects_invalid(bad):
+    """__post_init__ rejects a non-finite/zero conversion or an empty unit."""
+    kwargs = {"conversion": 1.0, "unit": "g", "description": "d", **bad}
+    with pytest.raises(ValueError):
+        SensorConfig(**kwargs)
+
+
+def test_unique_acquisition_name_dedups_and_warns(caplog):
+    """A colliding acquisition name is suffixed and warned, not silently dropped."""
+    logger = logging.getLogger("convert")
+    nwbfile = _make_minimal_nwbfile()
+    # first use of a name is returned unchanged
+    assert _unique_acquisition_name(nwbfile, "analog_input", logger) == "analog_input"
+    nwbfile.add_acquisition(
+        pynwb.TimeSeries(name="analog_input", data=[0], unit="unspecified", rate=1.0)
+    )
+    with caplog.at_level(logging.WARNING, logger="convert"):
+        assert (
+            _unique_acquisition_name(nwbfile, "analog_input", logger)
+            == "analog_input_2"
+        )
+    assert "already exists" in caplog.text
+    # a third collision increments the suffix
+    nwbfile.add_acquisition(
+        pynwb.TimeSeries(name="analog_input_2", data=[0], unit="unspecified", rate=1.0)
+    )
+    assert _unique_acquisition_name(nwbfile, "analog_input", logger) == "analog_input_3"
 
 
 def test_resolve_unit_default():

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -27,6 +27,20 @@ from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 from trodes_to_nwb.tests.utils import data_path
 
 
+class _FakeMuxChannel:
+    """Minimal stand-in for a multiplexed channel's parsed XML element.
+
+    Exposes just the ``attrib`` mapping the real
+    ``group_multiplexed_channels_by_schedule`` reads.
+    """
+
+    def __init__(self, byte, bit):
+        self.attrib = {
+            "interleavedDataIDByte": str(byte),
+            "interleavedDataIDBit": str(bit),
+        }
+
+
 class _FakeNeoIO:
     """Stand-in for a SpikeGadgetsRawIO, serving synthetic multiplexed data.
 
@@ -35,15 +49,24 @@ class _FakeNeoIO:
     should return. Groups not present are treated as disabled (no samples).
 
     ``schedule`` optionally maps each channel name to its
-    ``(interleavedDataIDByte, interleavedDataIDBit)`` pair, used by
-    ``group_multiplexed_channels_by_schedule``. When omitted, all channels are
-    treated as sharing one schedule (a single group), matching the common case.
+    ``(interleavedDataIDByte, interleavedDataIDBit)`` pair. When omitted, all
+    channels share one schedule (a single group), matching the common case. The
+    pairs populate ``multiplexed_channel_xml`` so this fake reuses the *real*
+    ``group_multiplexed_channels_by_schedule`` rather than re-implementing it.
     """
 
+    # reuse the production partition logic (it only reads multiplexed_channel_xml)
+    group_multiplexed_channels_by_schedule = (
+        SpikeGadgetsRawIO.group_multiplexed_channels_by_schedule
+    )
+
     def __init__(self, multiplexed_ids, decimated, schedule=None):
-        self.multiplexed_channel_xml = dict.fromkeys(multiplexed_ids)
+        schedule = schedule or {}
+        self.multiplexed_channel_xml = {
+            name: _FakeMuxChannel(*schedule.get(name, (0, 0)))
+            for name in multiplexed_ids
+        }
         self._decimated = decimated
-        self._schedule = schedule
 
     def get_analogsignal_multiplexed_decimated(self, channel_names):
         key = tuple(channel_names)
@@ -52,18 +75,6 @@ class _FakeNeoIO:
         return np.empty((0, len(channel_names)), dtype=np.int16), np.array(
             [], dtype=int
         )
-
-    def group_multiplexed_channels_by_schedule(self, channel_names):
-        if self._schedule is None:
-            return [list(channel_names)]
-        groups, order = {}, []
-        for name in channel_names:
-            key = self._schedule[name]
-            if key not in groups:
-                groups[key] = []
-                order.append(key)
-            groups[key].append(name)
-        return [groups[key] for key in order]
 
 
 class _FakeRecDCI:
@@ -613,6 +624,24 @@ def test_include_multiplexed_true_appends_mux_columns():
     n_mux = len(rec_dci.neo_io[0].multiplexed_channel_xml)
     assert n_mux > 0
     assert rec_dci.maxshape[1] == len(ecu_ids) + n_mux
+
+
+def test_include_multiplexed_flag_propagates_to_split_partials(monkeypatch):
+    """Every (split) reader inherits include_multiplexed, so the memory guard holds
+    on the large-file partial path, not just the single-reader case."""
+    monkeypatch.setattr("trodes_to_nwb.convert_ephys.MAXIMUM_ITERATOR_SIZE", 5000)
+    rec = str(data_path / "20230622_sample_01_a1.rec")
+    ecu_ids = convert_analog._get_ecu_analog_channel_ids(rec)
+    rec_dci = RecFileDataChunkIterator(
+        [rec],
+        nwb_hw_channel_order=ecu_ids,
+        stream_id="ECU_analog",
+        is_analog=True,
+        include_multiplexed=False,
+    )
+    assert len(rec_dci.neo_io) > 1  # the file was actually split into partials
+    assert all(not io._include_analog_multiplexed for io in rec_dci.neo_io)
+    assert rec_dci.maxshape[1] == len(ecu_ids)
 
 
 def test_no_ecu_headstage_only_writes_streams(monkeypatch):

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 
 import h5py
@@ -7,6 +8,9 @@ import pynwb
 
 from trodes_to_nwb import convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_analog import (
+    SENSOR_TYPE_CONFIG,
+    _categorize_sensor_channels,
+    _resolve_sensor_unit,
     add_analog_data,
     get_analog_channel_names,
     update_analog_data,
@@ -170,3 +174,93 @@ def test_selection_of_multiplexed_data():
             )
         )
         assert data.shape[1] == expected
+
+
+def test_categorize_all_sensor_types():
+    channels = [
+        "Headstage_AccelX",
+        "Headstage_AccelY",
+        "Headstage_AccelZ",
+        "Headstage_GyroX",
+        "Headstage_GyroY",
+        "Headstage_GyroZ",
+        "Headstage_MagX",
+        "Headstage_MagY",
+        "Headstage_MagZ",
+        "ECU_Ain1",
+        "Controller_Ain2",
+        "Foo_Bar",
+    ]
+    groups = _categorize_sensor_channels(channels)
+    assert groups["accelerometer"] == [
+        "Headstage_AccelX",
+        "Headstage_AccelY",
+        "Headstage_AccelZ",
+    ]
+    assert groups["gyroscope"] == [
+        "Headstage_GyroX",
+        "Headstage_GyroY",
+        "Headstage_GyroZ",
+    ]
+    assert groups["magnetometer"] == [
+        "Headstage_MagX",
+        "Headstage_MagY",
+        "Headstage_MagZ",
+    ]
+    assert groups["analog_input"] == ["ECU_Ain1", "Controller_Ain2"]
+    assert groups["other"] == ["Foo_Bar"]
+
+
+def test_categorize_preserves_input_order():
+    channels = ["Headstage_AccelY", "Headstage_AccelX", "Headstage_AccelZ"]
+    groups = _categorize_sensor_channels(channels)
+    # Order follows the input, not a sorted order.
+    assert groups["accelerometer"] == channels
+
+
+def test_categorize_patterns_anchored():
+    channels = [
+        "Headstage_AccelXfoo",
+        "Headstage_Accel",
+        "xHeadstage_AccelX",
+        "ECU_Ain10",
+    ]
+    groups = _categorize_sensor_channels(channels)
+    assert "accelerometer" not in groups
+    assert groups["analog_input"] == ["ECU_Ain10"]
+    assert sorted(groups["other"]) == [
+        "Headstage_Accel",
+        "Headstage_AccelXfoo",
+        "xHeadstage_AccelX",
+    ]
+
+
+def test_categorize_empty_returns_empty():
+    assert _categorize_sensor_channels([]) == {}
+
+
+def test_categorize_no_other_when_all_known():
+    groups = _categorize_sensor_channels(["Headstage_AccelX", "ECU_Ain1"])
+    assert "other" not in groups
+
+
+def test_sensor_config_conversion_unit_consistency():
+    assert SENSOR_TYPE_CONFIG["accelerometer"]["conversion"] == 0.000061
+    assert SENSOR_TYPE_CONFIG["accelerometer"]["unit"] == "g"
+    assert SENSOR_TYPE_CONFIG["gyroscope"]["conversion"] == 0.061
+    assert SENSOR_TYPE_CONFIG["gyroscope"]["unit"] == "d/s"
+    for sensor_type, config in SENSOR_TYPE_CONFIG.items():
+        for key in ("pattern", "conversion", "unit", "description"):
+            assert key in config, f"Missing {key} in {sensor_type} config"
+        re.compile(config["pattern"])  # raises re.error if invalid
+
+
+def test_resolve_unit_default():
+    assert _resolve_sensor_unit("accelerometer", "g", None) == "g"
+    assert _resolve_sensor_unit("accelerometer", "g", {}) == "g"
+    assert _resolve_sensor_unit("accelerometer", "g", {"sensor_units": {}}) == "g"
+
+
+def test_resolve_unit_override():
+    metadata = {"sensor_units": {"analog_input": "V"}}
+    assert _resolve_sensor_unit("analog_input", "unspecified", metadata) == "V"

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -125,8 +125,10 @@ def test_add_analog_data():
     # Headstage IMU: present with physical units, decimated to ~100 Hz.
     accel = nwbfile.acquisition["accelerometer"]
     gyro = nwbfile.acquisition["gyroscope"]
-    assert accel.unit == "g" and accel.conversion == 0.000061
-    assert gyro.unit == "d/s" and gyro.conversion == 0.061
+    assert accel.unit == "m/s^2"
+    assert accel.conversion == pytest.approx(0.000061 * 9.80665)  # g/LSB -> m/s^2
+    assert gyro.unit == "rad/s"
+    assert gyro.conversion == pytest.approx(0.061 * np.pi / 180)  # deg/s/LSB -> rad/s
     assert "magnetometer" not in nwbfile.acquisition  # disabled in this fixture
     for ts in (accel, gyro):
         t = ts.timestamps[:]
@@ -201,12 +203,14 @@ def test_add_analog_data_writes_sensor_acquisitions(monkeypatch):
 
     # IMU: decimated (materialized), raw int16 + its own true-rate timestamps
     acc = nwbfile.acquisition["accelerometer"]
-    assert acc.unit == "g" and acc.conversion == 0.000061
+    assert acc.unit == "m/s^2"
+    assert acc.conversion == pytest.approx(0.000061 * 9.80665)
     assert isinstance(acc.data, np.ndarray)  # decimated, not lazy H5DataIO
     assert (acc.data == accel_data).all()
     assert (acc.timestamps[:] == timestamps[accel_idx]).all()
     g = nwbfile.acquisition["gyroscope"]
-    assert g.conversion == 0.061
+    assert g.unit == "rad/s"
+    assert g.conversion == pytest.approx(0.061 * np.pi / 180)
     assert (g.data == gyro_data).all()
     assert (g.timestamps[:] == timestamps[gyro_idx]).all()
 
@@ -638,10 +642,15 @@ def test_categorize_no_other_when_all_known():
 
 
 def test_sensor_config_conversion_unit_consistency():
-    assert SENSOR_TYPE_CONFIG["accelerometer"].conversion == 0.000061
-    assert SENSOR_TYPE_CONFIG["accelerometer"].unit == "g"
-    assert SENSOR_TYPE_CONFIG["gyroscope"].conversion == 0.061
-    assert SENSOR_TYPE_CONFIG["gyroscope"].unit == "d/s"
+    # IMU stored in SI units (NWB convention): conversion maps raw int16 -> SI
+    assert SENSOR_TYPE_CONFIG["accelerometer"].unit == "m/s^2"
+    assert SENSOR_TYPE_CONFIG["accelerometer"].conversion == pytest.approx(
+        0.000061 * 9.80665
+    )
+    assert SENSOR_TYPE_CONFIG["gyroscope"].unit == "rad/s"
+    assert SENSOR_TYPE_CONFIG["gyroscope"].conversion == pytest.approx(
+        0.061 * np.pi / 180
+    )
     for sensor_type, config in SENSOR_TYPE_CONFIG.items():
         assert config.pattern is not None, f"{sensor_type} must have a pattern"
         re.compile(config.pattern)  # raises re.error if invalid

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -1,12 +1,17 @@
+from datetime import datetime, timezone
+import logging
 import os
 import re
 import shutil
+import types
 
 import h5py
+from hdmf.backends.hdf5 import H5DataIO
 import numpy as np
 import pynwb
+from pynwb import NWBFile
 
-from trodes_to_nwb import convert_rec_header, convert_yaml
+from trodes_to_nwb import convert_analog, convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_analog import (
     SENSOR_TYPE_CONFIG,
     _categorize_sensor_channels,
@@ -19,7 +24,68 @@ from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
 from trodes_to_nwb.tests.utils import data_path
 
 
+class _FakeRecDCI:
+    """Minimal stand-in for RecFileDataChunkIterator over synthetic analog data.
+
+    Exposes just the interface ``add_analog_data`` and
+    ``_AnalogChannelSubsetIterator`` rely on: a combined int16 array whose
+    columns are the ECU analog channels followed by the multiplexed headstage
+    channels, plus ``timestamps``, ``neo_io``, ``_get_maxshape`` and
+    ``_get_data``.
+    """
+
+    def __init__(self, combined_data, multiplexed_ids, timestamps):
+        self._data = combined_data
+        self.timestamps = timestamps
+        self.neo_io = [
+            types.SimpleNamespace(
+                multiplexed_channel_xml=dict.fromkeys(multiplexed_ids)
+            )
+        ]
+
+    def _get_maxshape(self):
+        return self._data.shape
+
+    def _get_data(self, selection):
+        return self._data[selection[0], selection[1]]
+
+
+def _make_minimal_nwbfile():
+    return NWBFile(
+        session_description="test",
+        identifier="test",
+        session_start_time=datetime(2023, 6, 22, tzinfo=timezone.utc),
+    )
+
+
+def _patch_analog_source(
+    monkeypatch, ecu_ids, multiplexed_ids, combined_data, timestamps
+):
+    """Patch add_analog_data's rec-file reads to serve synthetic data."""
+    monkeypatch.setattr(
+        convert_analog, "_get_ecu_analog_channel_ids", lambda path: list(ecu_ids)
+    )
+    fake = _FakeRecDCI(combined_data, multiplexed_ids, timestamps)
+    monkeypatch.setattr(
+        convert_analog, "RecFileDataChunkIterator", lambda *a, **k: fake
+    )
+    return fake
+
+
+def _materialize(dci):
+    """Read a GenericDataChunkIterator fully into a dense array."""
+    out = np.zeros(dci._get_maxshape(), dtype=dci._get_dtype())
+    for chunk in dci:
+        out[chunk.selection] = chunk.data
+    return out
+
+
 def test_add_analog_data():
+    """Integration test (requires downloaded .rec / reference .nwb fixtures).
+
+    Verifies the new acquisition layout and that recombining the per-sensor
+    raw int16 streams reproduces the reference combined analog stream exactly.
+    """
     # load metadata yml and make nwb file
     metadata_path = data_path / "20230622_sample_metadata.yml"
     metadata, _ = convert_yaml.load_metadata(metadata_path, [])
@@ -28,60 +94,172 @@ def test_add_analog_data():
     rec_header = convert_rec_header.read_header(rec_file)
     # make file with data
     nwbfile = convert_yaml.initialize_nwb(metadata, rec_header)
-    get_analog_channel_names(rec_header)
-    add_analog_data(nwbfile, [rec_file])
+    add_analog_data(nwbfile, [rec_file], metadata=metadata)
+
+    # New layout: per-sensor TimeSeries in acquisition, no combined processing stream.
+    assert "analog" not in nwbfile.processing
+    assert len(nwbfile.acquisition) > 0
+    if "accelerometer" in nwbfile.acquisition:
+        assert nwbfile.acquisition["accelerometer"].unit == "g"
+        assert nwbfile.acquisition["accelerometer"].conversion == 0.000061
+    if "gyroscope" in nwbfile.acquisition:
+        assert nwbfile.acquisition["gyroscope"].unit == "d/s"
+        assert nwbfile.acquisition["gyroscope"].conversion == 0.061
+
     # save file
     filename = "test_add_analog.nwb"
     with pynwb.NWBHDF5IO(filename, "w") as io:
         io.write(nwbfile)
-    # read new and rec_to_nwb_file. Compare.
-    with pynwb.NWBHDF5IO(filename, "r", load_namespaces=True) as io:
-        read_nwbfile = io.read()
-        assert "analog" in read_nwbfile.processing
-        assert "analog" in read_nwbfile.processing["analog"].data_interfaces
-        assert "analog" in read_nwbfile.processing["analog"]["analog"].time_series
-        assert read_nwbfile.processing["analog"]["analog"]["analog"].data.chunks == (
-            16384,
-            22,
-        )
+    try:
+        with pynwb.NWBHDF5IO(filename, "r", load_namespaces=True) as io:
+            read_nwbfile = io.read()
+            assert "analog" not in read_nwbfile.processing
 
-        with pynwb.NWBHDF5IO(rec_to_nwb_file, "r", load_namespaces=True) as io2:
-            old_nwbfile = io2.read()
+            # Map every channel back to its stored (raw int16) column.
+            new_by_channel = {}
+            for ts in read_nwbfile.acquisition.values():
+                channel_names = ts.description.split(": ", 1)[1].split(", ")
+                for col, channel in enumerate(channel_names):
+                    new_by_channel[channel] = ts.data[:, col]
 
-            # get index mapping of channels
-            id_order = read_nwbfile.processing["analog"]["analog"][
-                "analog"
-            ].description.split("   ")[:-1]
-            old_id_order = old_nwbfile.processing["analog"]["analog"][
-                "analog"
-            ].description.split("   ")[:-1]
-            index_order = [old_id_order.index(id) for id in id_order]
-            # TODO check that all the same channels are present
+            with pynwb.NWBHDF5IO(rec_to_nwb_file, "r", load_namespaces=True) as io2:
+                old_nwbfile = io2.read()
+                old_ts = old_nwbfile.processing["analog"]["analog"]["analog"]
+                old_id_order = old_ts.description.split("   ")[:-1]
 
-            # compare data
-            assert (
-                read_nwbfile.processing["analog"]["analog"]["analog"].data.shape
-                == old_nwbfile.processing["analog"]["analog"]["analog"].data.shape
-            )
-            # compare matching for first timepoint
-            assert (
-                read_nwbfile.processing["analog"]["analog"]["analog"].data[0, :]
-                == old_nwbfile.processing["analog"]["analog"]["analog"].data[0, :][
-                    index_order
-                ]
-            ).all()
-            # compare one channel across all timepoints
-            test_index = 14  # channel with non-zero data
-            assert (
-                read_nwbfile.processing["analog"]["analog"]["analog"].data[
-                    :, test_index
-                ]
-                == old_nwbfile.processing["analog"]["analog"]["analog"].data[
-                    :, index_order[test_index]
-                ]
-            ).all()
-    # cleanup
-    # os.remove(filename)
+                # same channels are present
+                assert set(new_by_channel) == set(old_id_order)
+                # raw values match the reference, per channel, across all timepoints
+                for col, channel in enumerate(old_id_order):
+                    assert (new_by_channel[channel] == old_ts.data[:, col]).all()
+    finally:
+        os.remove(filename)
+
+
+def test_add_analog_data_writes_sensor_acquisitions(monkeypatch):
+    """Synthetic: sensors land in acquisition, scaled via conversion, lazily."""
+    ecu_ids = ["ECU_Ain1", "ECU_Ain2"]
+    mux_ids = [
+        "Headstage_AccelX",
+        "Headstage_AccelY",
+        "Headstage_AccelZ",
+        "Headstage_GyroX",
+        "Headstage_GyroY",
+        "Headstage_GyroZ",
+    ]
+    all_ids = ecu_ids + mux_ids
+    n_time = 100
+    combined = np.arange(n_time * len(all_ids), dtype=np.int16).reshape(
+        n_time, len(all_ids)
+    )
+    timestamps = np.arange(n_time, dtype=float)
+    _patch_analog_source(monkeypatch, ecu_ids, mux_ids, combined, timestamps)
+
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["fake.rec"])
+
+    # replaced, not added alongside, the combined processing stream
+    assert "analog" not in nwbfile.processing
+    assert set(nwbfile.acquisition) == {"analog_input", "accelerometer", "gyroscope"}
+
+    accel = nwbfile.acquisition["accelerometer"]
+    assert accel.unit == "g"
+    assert accel.conversion == 0.000061
+    assert nwbfile.acquisition["gyroscope"].conversion == 0.061
+    assert nwbfile.acquisition["analog_input"].conversion == 1.0
+
+    # lazy: data backed by H5DataIO over an iterator, not a dense ndarray
+    assert isinstance(accel.data, H5DataIO)
+
+    # parity: stored raw int16 (no pre-scaling) reproduces the source columns
+    for ts in nwbfile.acquisition.values():
+        channel_names = ts.description.split(": ", 1)[1].split(", ")
+        materialized = _materialize(ts.data.data)
+        for col, channel in enumerate(channel_names):
+            assert (materialized[:, col] == combined[:, all_ids.index(channel)]).all()
+
+
+def test_add_analog_data_stream_spans_full_source_length(monkeypatch):
+    """Synthetic: the acquisition stream covers the whole source, not a prefix.
+
+    Guards the assembly side of multi-file handling: ``add_analog_data`` must
+    size each stream from the shared iterator's full ``_get_maxshape()`` rather
+    than reading a single file. (The real cross-file stitching lives in
+    ``RecFileDataChunkIterator`` and is covered by the integration tests.)
+    """
+    ecu_ids = ["ECU_Ain1"]
+    n_time = 250
+    combined = np.arange(n_time, dtype=np.int16).reshape(n_time, 1)
+    _patch_analog_source(
+        monkeypatch, ecu_ids, [], combined, np.arange(n_time, dtype=float)
+    )
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(nwbfile, ["a.rec", "b.rec"])
+    materialized = _materialize(nwbfile.acquisition["analog_input"].data.data)
+    assert materialized.shape[0] == n_time
+
+
+def test_add_analog_data_multifile_longer_than_single(monkeypatch):
+    """Integration: a two-file conversion is strictly longer than one file.
+
+    Requires downloaded .rec fixtures. Directly guards against reading only the
+    first rec file (the truncation failure mode), exercising the real
+    RecFileDataChunkIterator cross-file read.
+    """
+    rec1 = data_path / "20230622_sample_01_a1.rec"
+    rec2 = data_path / "20230622_sample_02_a1.rec"
+    metadata, _ = convert_yaml.load_metadata(
+        data_path / "20230622_sample_metadata.yml", []
+    )
+    rec_header = convert_rec_header.read_header(rec1)
+
+    nwb_single = convert_yaml.initialize_nwb(metadata, rec_header)
+    add_analog_data(nwb_single, [rec1], metadata=metadata)
+    nwb_multi = convert_yaml.initialize_nwb(metadata, rec_header)
+    add_analog_data(nwb_multi, [rec1, rec2], metadata=metadata)
+
+    stream_name = next(iter(nwb_single.acquisition))
+    len_single = nwb_single.acquisition[stream_name].data.data._get_maxshape()[0]
+    len_multi = nwb_multi.acquisition[stream_name].data.data._get_maxshape()[0]
+    assert len_multi > len_single
+
+
+def test_sensor_unit_metadata_override(monkeypatch):
+    """Synthetic: metadata overrides the unit label only, not the conversion."""
+    ecu_ids = ["ECU_Ain1"]
+    combined = np.zeros((10, 1), dtype=np.int16)
+    _patch_analog_source(monkeypatch, ecu_ids, [], combined, np.arange(10, dtype=float))
+    nwbfile = _make_minimal_nwbfile()
+    add_analog_data(
+        nwbfile, ["fake.rec"], metadata={"sensor_units": {"analog_input": "V"}}
+    )
+    analog_input = nwbfile.acquisition["analog_input"]
+    assert analog_input.unit == "V"
+    assert analog_input.conversion == 1.0
+
+
+def test_other_channels_logged(monkeypatch, caplog):
+    """Synthetic: unrecognized channels become an 'other' stream and are warned."""
+    ecu_ids = ["ECU_Ain1", "Mystery_Chan"]
+    combined = np.zeros((5, 2), dtype=np.int16)
+    _patch_analog_source(monkeypatch, ecu_ids, [], combined, np.arange(5, dtype=float))
+    nwbfile = _make_minimal_nwbfile()
+    with caplog.at_level(logging.WARNING, logger="convert"):
+        add_analog_data(nwbfile, ["fake.rec"])
+    assert "other" in nwbfile.acquisition
+    assert "Mystery_Chan" in caplog.text
+
+
+def test_analog_subset_iterator_parity():
+    """The subset iterator yields the requested columns (non-contiguous, reordered)."""
+    n_time, n_cols = 100, 5
+    data = np.arange(n_time * n_cols, dtype=np.int16).reshape(n_time, n_cols)
+    fake = _FakeRecDCI(data, [], np.arange(n_time, dtype=float))
+    columns = [3, 1, 4]  # non-contiguous and reordered
+    iterator = convert_analog._AnalogChannelSubsetIterator(fake, columns)
+    assert iterator._get_maxshape() == (n_time, len(columns))
+    assert iterator._get_dtype() == np.dtype("int16")
+    assert (_materialize(iterator) == data[:, columns]).all()
 
 
 def test_update_analog_data():

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -1,3 +1,4 @@
+from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
 import logging
 import os
@@ -563,14 +564,18 @@ def test_categorize_no_other_when_all_known():
 
 
 def test_sensor_config_conversion_unit_consistency():
-    assert SENSOR_TYPE_CONFIG["accelerometer"]["conversion"] == 0.000061
-    assert SENSOR_TYPE_CONFIG["accelerometer"]["unit"] == "g"
-    assert SENSOR_TYPE_CONFIG["gyroscope"]["conversion"] == 0.061
-    assert SENSOR_TYPE_CONFIG["gyroscope"]["unit"] == "d/s"
+    assert SENSOR_TYPE_CONFIG["accelerometer"].conversion == 0.000061
+    assert SENSOR_TYPE_CONFIG["accelerometer"].unit == "g"
+    assert SENSOR_TYPE_CONFIG["gyroscope"].conversion == 0.061
+    assert SENSOR_TYPE_CONFIG["gyroscope"].unit == "d/s"
     for sensor_type, config in SENSOR_TYPE_CONFIG.items():
-        for key in ("pattern", "conversion", "unit", "description"):
-            assert key in config, f"Missing {key} in {sensor_type} config"
-        re.compile(config["pattern"])  # raises re.error if invalid
+        assert config.pattern is not None, f"{sensor_type} must have a pattern"
+        re.compile(config.pattern)  # raises re.error if invalid
+
+
+def test_sensor_config_is_immutable():
+    with pytest.raises(FrozenInstanceError):
+        SENSOR_TYPE_CONFIG["accelerometer"].conversion = 1.0
 
 
 def test_resolve_unit_default():

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import shutil
-import types
 
 import h5py
 from hdmf.backends.hdf5 import H5DataIO
@@ -22,7 +21,29 @@ from trodes_to_nwb.convert_analog import (
     update_analog_data,
 )
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 from trodes_to_nwb.tests.utils import data_path
+
+
+class _FakeNeoIO:
+    """Stand-in for a SpikeGadgetsRawIO, serving synthetic multiplexed data.
+
+    ``decimated`` maps a tuple of channel names (one sensor group) to the
+    ``(data, update_indices)`` that ``get_analogsignal_multiplexed_decimated``
+    should return. Groups not present are treated as disabled (no samples).
+    """
+
+    def __init__(self, multiplexed_ids, decimated):
+        self.multiplexed_channel_xml = dict.fromkeys(multiplexed_ids)
+        self._decimated = decimated
+
+    def get_analogsignal_multiplexed_decimated(self, channel_names):
+        key = tuple(channel_names)
+        if key in self._decimated:
+            return self._decimated[key]
+        return np.empty((0, len(channel_names)), dtype=np.int16), np.array(
+            [], dtype=int
+        )
 
 
 class _FakeRecDCI:
@@ -31,18 +52,15 @@ class _FakeRecDCI:
     Exposes just the interface ``add_analog_data`` and
     ``_AnalogChannelSubsetIterator`` rely on: a combined int16 array whose
     columns are the ECU analog channels followed by the multiplexed headstage
-    channels, plus ``timestamps``, ``neo_io``, ``_get_maxshape`` and
-    ``_get_data``.
+    channels (the latter are read via ``neo_io`` decimation, not ``_get_data``),
+    plus ``timestamps``, ``n_time``, ``neo_io``, ``maxshape`` and ``_get_data``.
     """
 
-    def __init__(self, combined_data, multiplexed_ids, timestamps):
+    def __init__(self, combined_data, multiplexed_ids, timestamps, decimated=None):
         self._data = combined_data
         self.timestamps = timestamps
-        self.neo_io = [
-            types.SimpleNamespace(
-                multiplexed_channel_xml=dict.fromkeys(multiplexed_ids)
-            )
-        ]
+        self.n_time = [combined_data.shape[0]]
+        self.neo_io = [_FakeNeoIO(multiplexed_ids, decimated or {})]
 
     @property
     def maxshape(self):
@@ -64,13 +82,13 @@ def _make_minimal_nwbfile():
 
 
 def _patch_analog_source(
-    monkeypatch, ecu_ids, multiplexed_ids, combined_data, timestamps
+    monkeypatch, ecu_ids, multiplexed_ids, combined_data, timestamps, decimated=None
 ):
     """Patch add_analog_data's rec-file reads to serve synthetic data."""
     monkeypatch.setattr(
         convert_analog, "_get_ecu_analog_channel_ids", lambda path: list(ecu_ids)
     )
-    fake = _FakeRecDCI(combined_data, multiplexed_ids, timestamps)
+    fake = _FakeRecDCI(combined_data, multiplexed_ids, timestamps, decimated)
     monkeypatch.setattr(
         convert_analog, "RecFileDataChunkIterator", lambda *a, **k: fake
     )
@@ -88,100 +106,116 @@ def _materialize(dci):
 def test_add_analog_data():
     """Integration test (requires downloaded .rec / reference .nwb fixtures).
 
-    Verifies the new acquisition layout and that recombining the per-sensor
-    raw int16 streams reproduces the reference combined analog stream exactly.
+    ECU analog inputs stay at the full acquisition rate and match the reference
+    combined stream channel-for-channel; headstage IMU sensors are decimated to
+    their true ~100 Hz rate with explicit timestamps.
     """
-    # load metadata yml and make nwb file
-    metadata_path = data_path / "20230622_sample_metadata.yml"
-    metadata, _ = convert_yaml.load_metadata(metadata_path, [])
+    metadata, _ = convert_yaml.load_metadata(
+        data_path / "20230622_sample_metadata.yml", []
+    )
     rec_file = data_path / "20230622_sample_01_a1.rec"
-    rec_to_nwb_file = data_path / "20230622_155936.nwb"  # comparison file
+    rec_to_nwb_file = data_path / "20230622_155936.nwb"  # reference (old layout)
     rec_header = convert_rec_header.read_header(rec_file)
-    # make file with data
     nwbfile = convert_yaml.initialize_nwb(metadata, rec_header)
     add_analog_data(nwbfile, [rec_file], metadata=metadata)
 
-    # New layout: per-sensor TimeSeries in acquisition, no combined processing stream.
     assert "analog" not in nwbfile.processing
-    assert len(nwbfile.acquisition) > 0
-    if "accelerometer" in nwbfile.acquisition:
-        assert nwbfile.acquisition["accelerometer"].unit == "g"
-        assert nwbfile.acquisition["accelerometer"].conversion == 0.000061
-    if "gyroscope" in nwbfile.acquisition:
-        assert nwbfile.acquisition["gyroscope"].unit == "d/s"
-        assert nwbfile.acquisition["gyroscope"].conversion == 0.061
+    imu_names = {"accelerometer", "gyroscope", "magnetometer"}
 
-    # save file
+    # Headstage IMU: present with physical units, decimated to ~100 Hz.
+    accel = nwbfile.acquisition["accelerometer"]
+    gyro = nwbfile.acquisition["gyroscope"]
+    assert accel.unit == "g" and accel.conversion == 0.000061
+    assert gyro.unit == "d/s" and gyro.conversion == 0.061
+    assert "magnetometer" not in nwbfile.acquisition  # disabled in this fixture
+    for ts in (accel, gyro):
+        t = ts.timestamps[:]
+        assert np.all(np.diff(t) > 0)  # strictly increasing
+        rate = 1.0 / np.median(np.diff(t))
+        assert 90.0 < rate < 110.0  # true sensor rate, not the 30 kHz held rate
+
+    # IMU values match the reader's decimated output exactly (raw int16).
+    io = SpikeGadgetsRawIO(filename=str(rec_file))
+    io.parse_header()
+    for name, channels in (
+        ("accelerometer", ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]),
+        ("gyroscope", ["Headstage_GyroX", "Headstage_GyroY", "Headstage_GyroZ"]),
+    ):
+        expected, _ = io.get_analogsignal_multiplexed_decimated(channels)
+        assert (nwbfile.acquisition[name].data[:] == expected).all()
+
+    # ECU analog inputs: full-rate, match the reference combined stream per channel.
     filename = "test_add_analog.nwb"
-    with pynwb.NWBHDF5IO(filename, "w") as io:
-        io.write(nwbfile)
+    with pynwb.NWBHDF5IO(filename, "w") as io_w:
+        io_w.write(nwbfile)
     try:
-        with pynwb.NWBHDF5IO(filename, "r", load_namespaces=True) as io:
-            read_nwbfile = io.read()
-            assert "analog" not in read_nwbfile.processing
-
-            # Map every channel back to its stored (raw int16) column.
+        with pynwb.NWBHDF5IO(filename, "r", load_namespaces=True) as io_r:
+            read_nwbfile = io_r.read()
             new_by_channel = {}
-            for ts in read_nwbfile.acquisition.values():
-                channel_names = ts.description.split(": ", 1)[1].split(", ")
-                for col, channel in enumerate(channel_names):
+            for nm, ts in read_nwbfile.acquisition.items():
+                if nm in imu_names:
+                    continue
+                channels = ts.description.split(": ", 1)[1].split(", ")
+                for col, channel in enumerate(channels):
                     new_by_channel[channel] = ts.data[:, col]
 
             with pynwb.NWBHDF5IO(rec_to_nwb_file, "r", load_namespaces=True) as io2:
-                old_nwbfile = io2.read()
-                old_ts = old_nwbfile.processing["analog"]["analog"]["analog"]
+                old_ts = io2.read().processing["analog"]["analog"]["analog"]
                 old_id_order = old_ts.description.split("   ")[:-1]
-
-                # same channels are present
-                assert set(new_by_channel) == set(old_id_order)
-                # raw values match the reference, per channel, across all timepoints
+                ecu_channels = [c for c in old_id_order if c in new_by_channel]
+                # every full-rate ECU channel is present and matches exactly
+                assert ecu_channels  # sanity: some ECU channels exist
                 for col, channel in enumerate(old_id_order):
-                    assert (new_by_channel[channel] == old_ts.data[:, col]).all()
+                    if channel in new_by_channel:
+                        assert (new_by_channel[channel] == old_ts.data[:, col]).all()
     finally:
         os.remove(filename)
 
 
 def test_add_analog_data_writes_sensor_acquisitions(monkeypatch):
-    """Synthetic: sensors land in acquisition, scaled via conversion, lazily."""
+    """Synthetic: ECU stays lazy/full-rate; IMU is decimated with own timestamps."""
     ecu_ids = ["ECU_Ain1", "ECU_Ain2"]
-    mux_ids = [
-        "Headstage_AccelX",
-        "Headstage_AccelY",
-        "Headstage_AccelZ",
-        "Headstage_GyroX",
-        "Headstage_GyroY",
-        "Headstage_GyroZ",
-    ]
-    all_ids = ecu_ids + mux_ids
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    gyro = ["Headstage_GyroX", "Headstage_GyroY", "Headstage_GyroZ"]
+    mux_ids = accel + gyro
     n_time = 100
-    combined = np.arange(n_time * len(all_ids), dtype=np.int16).reshape(
-        n_time, len(all_ids)
-    )
+    combined = np.arange(
+        n_time * (len(ecu_ids) + len(mux_ids)), dtype=np.int16
+    ).reshape(n_time, -1)
     timestamps = np.arange(n_time, dtype=float)
-    _patch_analog_source(monkeypatch, ecu_ids, mux_ids, combined, timestamps)
+    # accel and gyro update on interleaved (different) packets
+    accel_idx, gyro_idx = np.array([10, 40, 70]), np.array([20, 50, 80])
+    accel_data = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.int16)
+    gyro_data = np.array([[10, 11, 12], [13, 14, 15], [16, 17, 18]], dtype=np.int16)
+    decimated = {
+        tuple(accel): (accel_data, accel_idx),
+        tuple(gyro): (gyro_data, gyro_idx),
+    }
+    _patch_analog_source(monkeypatch, ecu_ids, mux_ids, combined, timestamps, decimated)
 
     nwbfile = _make_minimal_nwbfile()
     add_analog_data(nwbfile, ["fake.rec"])
 
-    # replaced, not added alongside, the combined processing stream
     assert "analog" not in nwbfile.processing
     assert set(nwbfile.acquisition) == {"analog_input", "accelerometer", "gyroscope"}
 
-    accel = nwbfile.acquisition["accelerometer"]
-    assert accel.unit == "g"
-    assert accel.conversion == 0.000061
-    assert nwbfile.acquisition["gyroscope"].conversion == 0.061
-    assert nwbfile.acquisition["analog_input"].conversion == 1.0
+    # IMU: decimated (materialized), raw int16 + its own true-rate timestamps
+    acc = nwbfile.acquisition["accelerometer"]
+    assert acc.unit == "g" and acc.conversion == 0.000061
+    assert isinstance(acc.data, np.ndarray)  # decimated, not lazy H5DataIO
+    assert (acc.data == accel_data).all()
+    assert (acc.timestamps[:] == timestamps[accel_idx]).all()
+    g = nwbfile.acquisition["gyroscope"]
+    assert g.conversion == 0.061
+    assert (g.data == gyro_data).all()
+    assert (g.timestamps[:] == timestamps[gyro_idx]).all()
 
-    # lazy: data backed by H5DataIO over an iterator, not a dense ndarray
-    assert isinstance(accel.data, H5DataIO)
-
-    # parity: stored raw int16 (no pre-scaling) reproduces the source columns
-    for ts in nwbfile.acquisition.values():
-        channel_names = ts.description.split(": ", 1)[1].split(", ")
-        materialized = _materialize(ts.data.data)
-        for col, channel in enumerate(channel_names):
-            assert (materialized[:, col] == combined[:, all_ids.index(channel)]).all()
+    # ECU: lazy/full-rate, raw int16 parity with the source columns
+    ecu = nwbfile.acquisition["analog_input"]
+    assert ecu.conversion == 1.0
+    assert isinstance(ecu.data, H5DataIO)
+    materialized = _materialize(ecu.data.data)
+    assert (materialized == combined[:, : len(ecu_ids)]).all()
 
 
 def test_add_analog_data_stream_spans_full_source_length(monkeypatch):
@@ -289,10 +323,11 @@ def test_add_analog_data_no_channels_returns(monkeypatch, caplog):
 def test_magnetometer_and_other_units(monkeypatch):
     """Magnetometer and 'other' streams carry conversion 1.0 / unit 'unspecified'."""
     ecu_ids = ["Mystery_Chan"]
-    mux_ids = ["Headstage_MagX", "Headstage_MagY", "Headstage_MagZ"]
-    combined = np.zeros((10, len(ecu_ids) + len(mux_ids)), dtype=np.int16)
+    mag = ["Headstage_MagX", "Headstage_MagY", "Headstage_MagZ"]
+    combined = np.zeros((10, len(ecu_ids) + len(mag)), dtype=np.int16)
+    decimated = {tuple(mag): (np.ones((3, 3), dtype=np.int16), np.array([1, 4, 7]))}
     _patch_analog_source(
-        monkeypatch, ecu_ids, mux_ids, combined, np.arange(10, dtype=float)
+        monkeypatch, ecu_ids, mag, combined, np.arange(10, dtype=float), decimated
     )
     nwbfile = _make_minimal_nwbfile()
     add_analog_data(nwbfile, ["fake.rec"])
@@ -301,23 +336,62 @@ def test_magnetometer_and_other_units(monkeypatch):
         assert nwbfile.acquisition[name].unit == "unspecified"
 
 
-def test_sensor_streams_share_one_timestamps(monkeypatch):
-    """Streams after the first link to the first stream's timestamps (stored once)."""
+def test_disabled_sensor_omitted_and_logged(monkeypatch, caplog):
+    """A headstage sensor that never updates is omitted with a WARNING."""
     ecu_ids = ["ECU_Ain1"]
-    mux_ids = ["Headstage_AccelX"]
-    combined = np.zeros((10, 2), dtype=np.int16)
+    mag = ["Headstage_MagX", "Headstage_MagY", "Headstage_MagZ"]
+    combined = np.zeros((10, len(ecu_ids) + len(mag)), dtype=np.int16)
+    # no decimated entry for mag -> the fake reports it as disabled (no samples)
     _patch_analog_source(
-        monkeypatch, ecu_ids, mux_ids, combined, np.arange(10, dtype=float)
+        monkeypatch, ecu_ids, mag, combined, np.arange(10, dtype=float)
     )
     nwbfile = _make_minimal_nwbfile()
+    with caplog.at_level(logging.WARNING, logger="convert"):
+        add_analog_data(nwbfile, ["fake.rec"])
+    assert "magnetometer" not in nwbfile.acquisition
+    assert "no sampled data (disabled)" in caplog.text
+
+
+def test_ecu_streams_share_timestamps_imu_independent(monkeypatch):
+    """ECU streams link to one shared timestamps array; IMU has its own."""
+    ecu_ids = ["ECU_Ain1", "Mystery_Chan"]  # -> analog_input + other, both full-rate
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    combined = np.zeros((10, len(ecu_ids) + len(accel)), dtype=np.int16)
+    accel_idx = np.array([2, 5, 8])
+    decimated = {tuple(accel): (np.zeros((3, 3), dtype=np.int16), accel_idx)}
+    timestamps = np.arange(10, dtype=float)
+    _patch_analog_source(monkeypatch, ecu_ids, accel, combined, timestamps, decimated)
+    nwbfile = _make_minimal_nwbfile()
     add_analog_data(nwbfile, ["fake.rec"])
-    streams = list(nwbfile.acquisition.values())
-    assert len(streams) >= 2
-    # every stream resolves to the same timestamps array (stored once, linked),
-    # and at least one stream links rather than owning a second copy
-    timestamp_arrays = [ts.timestamps for ts in streams]
-    assert all(arr is timestamp_arrays[0] for arr in timestamp_arrays)
-    assert any(ts.timestamp_link for ts in streams)
+
+    ai = nwbfile.acquisition["analog_input"]
+    other = nwbfile.acquisition["other"]
+    # the two ECU streams resolve to the same timestamps array (stored once)
+    assert ai.timestamps is other.timestamps
+    assert any(s.timestamp_link for s in (ai, other))
+    # the IMU stream is on its own (decimated) timebase
+    acc = nwbfile.acquisition["accelerometer"]
+    assert acc.timestamps is not ai.timestamps
+    assert (acc.timestamps[:] == timestamps[accel_idx]).all()
+
+
+def test_get_decimated_multiplexed_real_data():
+    """Reader returns true-rate IMU samples; empty for disabled; raises cross-sensor."""
+    io = SpikeGadgetsRawIO(filename=str(data_path / "20230622_sample_01_a1.rec"))
+    io.parse_header()
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    data, idx = io.get_analogsignal_multiplexed_decimated(accel)
+    assert data.shape == (idx.size, 3) and idx.size > 0
+    assert 90.0 < 30000.0 / np.median(np.diff(idx)) < 110.0  # ~100 Hz @ 30 kHz
+    # disabled sensor -> empty
+    mag = ["Headstage_MagX", "Headstage_MagY", "Headstage_MagZ"]
+    mag_data, mag_idx = io.get_analogsignal_multiplexed_decimated(mag)
+    assert mag_data.shape == (0, 3) and mag_idx.size == 0
+    # channels from different sensors don't share an update schedule
+    with pytest.raises(ValueError, match="share an update schedule"):
+        io.get_analogsignal_multiplexed_decimated(
+            ["Headstage_AccelX", "Headstage_GyroX"]
+        )
 
 
 def test_unknown_sensor_units_key_warns(monkeypatch, caplog):

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -454,6 +454,63 @@ def test_get_decimated_multiplexed_real_data():
         )
 
 
+def test_accelerometer_conversion_recovers_gravity():
+    """Physical check that the accelerometer SI conversion is correct.
+
+    An accelerometer always senses gravity, so the magnitude of the 3-axis
+    reading must be ~1 g (9.80665 m/s^2). After applying the stored conversion,
+    the median |acceleration| over the session should land near standard gravity
+    (within tolerance for sensor bias and the animal's own motion). A wrong
+    conversion factor (e.g. forgetting the g->m/s^2 step, or an LSB error) would
+    push this far from 1 g.
+    """
+    io = SpikeGadgetsRawIO(filename=str(data_path / "20230622_sample_01_a1.rec"))
+    io.parse_header()
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+    raw, _ = io.get_analogsignal_multiplexed_decimated(accel)
+    physical = raw.astype(float) * SENSOR_TYPE_CONFIG["accelerometer"].conversion
+    magnitude = np.sqrt((physical**2).sum(axis=1))  # m/s^2
+    median_g = np.median(magnitude) / 9.80665
+    # measured ~1.04 g on this fixture; band catches gross (factor) conversion errors
+    assert 0.8 < median_g < 1.25, f"|accel| median {median_g:.3f} g not near gravity"
+
+
+def test_old_and_new_layouts_agree_at_aligned_timepoints():
+    """Convert the same rec file the old (combined, held) and new (per-sensor,
+    decimated) way; the IMU values at the timepoints they share are identical.
+
+    The old combined stream stored raw int16 with no scaling (unit='-1'); the new
+    stream stores the same raw int16 plus a conversion to SI. So at the kept
+    timepoints the raw counts match exactly, and the new physical value is the old
+    raw count times the documented conversion.
+    """
+    rec = data_path / "20230622_sample_01_a1.rec"
+    metadata, _ = convert_yaml.load_metadata(
+        data_path / "20230622_sample_metadata.yml", []
+    )
+    header = convert_rec_header.read_header(rec)
+    new_nwb = convert_yaml.initialize_nwb(metadata, header)
+    add_analog_data(new_nwb, [rec], metadata=metadata)
+    accel_ts = new_nwb.acquisition["accelerometer"]
+    accel = ["Headstage_AccelX", "Headstage_AccelY", "Headstage_AccelZ"]
+
+    io = SpikeGadgetsRawIO(filename=str(rec))
+    io.parse_header()
+    held = io.get_analogsignal_multiplexed()  # old way: full-rate sample-and-held
+    mux_ids = list(io.multiplexed_channel_xml.keys())
+    cols = [mux_ids.index(c) for c in accel]
+    _, idx = io.get_analogsignal_multiplexed_decimated(accel)
+
+    # raw counts are preserved at the aligned (kept) timepoints: the new stream is
+    # the same data as the old, relocated/decimated, plus an SI conversion factor.
+    # (That the conversion is physically correct is verified separately by
+    # test_accelerometer_conversion_recovers_gravity.)
+    new_raw = accel_ts.data[:]
+    old_raw_at_aligned = held[np.ix_(idx, cols)]
+    assert np.array_equal(new_raw, old_raw_at_aligned)
+    assert accel_ts.conversion == pytest.approx(0.000061 * 9.80665)
+
+
 def test_unknown_sensor_units_key_warns(monkeypatch, caplog):
     """A misspelled sensor_units key is warned about, not silently ignored."""
     ecu_ids = ["ECU_Ain1"]


### PR DESCRIPTION
## Problem

Headstage sensor data was not usable as physical measurements in the converted NWB files.

All analog channels — the headstage IMU sensors (accelerometer, gyroscope, magnetometer) **and** the ECU analog inputs — were written into a single combined `TimeSeries` at `processing["analog"]["analog"]["analog"]` with `unit="-1"` and no scaling. As a result (per #19):

- Accelerometer and gyroscope data sat as **raw integer counts** with no way to recover physical units. The SpikeGadgets headstage encodes accelerometer at `±2 g` full scale (0.000061 g/LSB) and gyroscope at `±2000 deg/s` (0.061 deg/s/LSB), but that scaling lived nowhere in the file. (These are now stored in SI — `m/s^2`, `rad/s` — per the NWB unit convention, with the native scale noted in each stream's description.)
- Every sensor was lumped into one opaque multi-channel array, so a downstream consumer couldn't ask for "the accelerometer" — it had to know channel-index offsets into the combined stream.
- **The IMU was stored at the wrong rate.** The headstage IMU truly samples at ~100 Hz, but the `.rec` stream expands it to the ~30 kHz acquisition rate by **sample-and-hold** (each real sample repeated ~300×). The combined stream stored that inflated, held version, so downstream tools had to guess which samples were real (e.g. via fragile change-detection).

## Solution

`add_analog_data` now writes **one `TimeSeries` per sensor type into `nwbfile.acquisition`**, each with the correct physical unit, and handles the two kinds of analog data according to how they're actually sampled:

| acquisition stream | unit | conversion | rate | storage |
|---|---|---|---|---|
| `accelerometer` | `m/s^2` | `5.98e-4` | **~100 Hz (true)** | decimated, explicit timestamps |
| `gyroscope` | `rad/s` | `1.065e-3` | **~100 Hz (true)** | decimated, explicit timestamps |
| `magnetometer` | `unspecified` | `1.0` | ~100 Hz | decimated (omitted if disabled) |
| `analog_input` (ECU `Ain*`) | `unspecified`¹ | `1.0` | full acquisition rate | lazy, chunked (`H5DataIO`) |
| `other` | `unspecified` | `1.0` | full acquisition rate | lazy, chunked |

Two design choices do the heavy lifting:

1. **Scaling rides on `TimeSeries.conversion`** (`stored_int16 × conversion = value in unit`) instead of eagerly multiplying the array. Raw `int16` is stored and the scale is applied on read.

2. **The IMU is decimated back to its true rate.** `SpikeGadgetsRawIO.get_analogsignal_multiplexed_decimated()` uses the per-packet `interleavedDataIDBit` update flags — the ground-truth record of which packets carry a fresh sample — to drop the sample-and-hold repeats, and returns the genuine samples plus their packet indices for timestamps. This is more reliable than downstream change-detection (which silently drops genuine consecutive-equal samples). Accelerometer and gyroscope are sampled on **interleaved** schedules (verified on real data: they never share an update packet), so each gets its **own timestamps** — which the per-sensor `TimeSeries` structure accommodates naturally. A sensor that never updates (a disabled magnetometer/Ain) is **omitted with a warning** rather than stored as a meaningless constant.

<img width="5002" height="1836" alt="pr168_imu_sample_and_hold" src="https://github.com/user-attachments/assets/34cd0032-f95f-4907-9424-e4c6cf82a5af" />


ECU analog inputs are genuinely continuous, so they stay at the full acquisition rate, lazy and chunked via `H5DataIO` (memory independent of session length).

Channels are classified by name via a frozen `SensorConfig` registry. Optional `sensor_units` metadata overrides a sensor's unit *label* (not its conversion); unknown keys are warned about, not silently ignored.

¹ ECU analog inputs are relocated/named but **not** given a physical conversion — no counts→volts factor is defined — so they remain raw `int16`, `unit="unspecified"` (label override allowed). See "Out of scope".

## ⚠️ Breaking change

Analog data moves from `processing["analog"]["analog"]["analog"]` to per-sensor `nwbfile.acquisition[...]` streams. Downstream readers (Spyglass ingestion, analysis notebooks) that read `processing["analog"]` must update.

- `ts.data[:]` returns **raw int16 counts**; multiply by `ts.conversion` for physical units.
- **IMU streams are now ~100 Hz with their own `timestamps`**, not the acquisition rate — code that assumed a fixed sample rate or alignment to the ephys clock must use the stored timestamps.
- Existing files in the old layout can still be repaired with `update_analog_data`, which targets the legacy layout and raises a clear error on a new-layout file.
- Documented in `CHANGELOG.md` with a migration note.

## Testing

Validated against the real test dataset (downloaded fixtures), plus synthetic/monkeypatched tests that run with no bulk data:

- **Decimation reader** — returns `(n, 3)` IMU at ~100 Hz with packet indices; empty for a disabled sensor; raises when channels from different sensors (different update schedules) are mixed.
- **`add_analog_data`** — accelerometer/gyroscope written as decimated `(n, 3)` at ~100 Hz with strictly-increasing timestamps and correct `conversion`/`unit`, matching the reader's decimated output exactly; magnetometer/`Ain` (disabled in the fixture) omitted + logged; ECU analog inputs full-rate and matching the reference combined stream channel-for-channel; ECU streams share one timestamps dataset while each IMU stream is independent.
- **Full conversion** (`test_convert.py`) and **multi-file** paths pass against real data.
- Raw-int16 parity guards against double-scaling; lazy `H5DataIO` for ECU guards against eager materialization.

## Out of scope / follow-ups

- A numeric counts→volts conversion for ECU analog inputs (none is defined per rig).
- Updating Spyglass / downstream ingestion to read the new layout and the ~100 Hz IMU timebase (separate repo; sequence before files built with this version are ingested).

## Notes

This replaces #142, which was built from a stale base (~18 commits behind `main`) and would have reverted unrelated fixes (analog demuxing, pynwb 3.1 migration, `update_analog_data`, etc.). This PR is a clean reimplementation on current `main` and incorporates the review feedback from #142.

Fixes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

