### PR TITLE
Unwrap uint32 Trodes timestamps for recordings past the ~39.77 h wrap (#169)

### DIFF
--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -27,6 +27,35 @@ TIMESTAMP_SIZE_BYTES = 4  # uint32
 SYSCLOCK_SIZE_BYTES = 8  # int64
 EPHYS_SAMPLE_SIZE_BYTES = 2  # int16
 EXPECTED_TIMESTAMP_DIFF_DROP = 2  # Indicates a single dropped packet
+UINT32_WRAP = 2**32  # Trodes timestamp is a uint32 sample counter; it wraps here
+
+
+def _unwrap_uint32(values: np.ndarray) -> np.ndarray:
+    """Unwrap a monotonically increasing uint32 counter that may have wrapped.
+
+    The Trodes per-packet timestamp is a uint32 sample counter that rolls over
+    after ``2**32`` samples (~39.77 h at 30 kHz). A rollover appears as a large
+    negative jump once the values are viewed as signed integers. This adds
+    ``2**32`` at and after each detected wrap and returns ``int64`` values that
+    are globally monotonic relative to ``values[0]``.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        1D array of uint32 timestamp counter values.
+
+    Returns
+    -------
+    np.ndarray
+        ``int64`` array of the same shape, unwrapped.
+    """
+    unwrapped = np.asarray(values, dtype=np.int64)
+    if unwrapped.size < 2:
+        return unwrapped
+    wraps = np.diff(unwrapped) < -(UINT32_WRAP // 2)
+    offsets = np.zeros(unwrapped.size, dtype=np.int64)
+    offsets[1:] = np.cumsum(wraps) * UINT32_WRAP
+    return unwrapped + offsets
 
 
 class SpikeGadgetsRawIO(BaseRawIO):
@@ -494,6 +523,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         # initialize systime parameters as empty dict so can check if they have been set in a get_regressed_systime call
         self.regressed_systime_parameters = {}
+        # offset of this object's first sample within the full recording; 0 for a
+        # full file, set to start_index for partial iterators. Used to anchor the
+        # uint32 timestamp unwrap to a single global axis (see get_regressed_systime).
+        self._global_sample_offset = 0
 
         self._generate_minimal_annotations()
         # info from GlobalConfiguration in xml are copied to block and seg annotations
@@ -998,11 +1031,27 @@ class SpikeGadgetsRawIO(BaseRawIO):
             A NumPy array containing the adjusted system timestamps.
         """
         NANOSECONDS_PER_SECOND = 1e9
-        # get trodes timestamp values
-        trodestime = self.get_analogsignal_timestamps(i_start, i_stop)
-        # Convert
-        trodestime_index = np.asarray(trodestime, dtype=np.float64)
+        # Get the raw uint32 Trodes timestamps for this slice. The counter wraps
+        # every 2**32 samples (~39.77 h at 30 kHz); unwrap to a globally
+        # monotonic axis anchored at the full recording's sample 0 so that split
+        # (partial) iterators -- which inherit the fitted slope/intercept and may
+        # read a post-wrap sub-range -- land on the same axis (see #169).
+        trodestime = np.asarray(self.get_analogsignal_timestamps(i_start, i_stop))
+        global_start = int(getattr(self, "_global_sample_offset", 0)) + int(
+            i_start or 0
+        )
         if not self.regressed_systime_parameters:
+            # Fitting call (the full recording, in the normal pipeline). Unwrap
+            # this slice and record the global sample index of every wrap so
+            # partial iterators can reconstruct the identical axis.
+            trodestime_index = _unwrap_uint32(trodestime).astype(np.float64)
+            wrap_sample_indices = (
+                np.flatnonzero(
+                    np.diff(trodestime.astype(np.int64)) < -(UINT32_WRAP // 2)
+                )
+                + 1
+                + global_start
+            )
             # get raw systime values
             systime_seconds = self.get_sys_clock(i_start, i_stop)
             # regress
@@ -1010,10 +1059,22 @@ class SpikeGadgetsRawIO(BaseRawIO):
             self.regressed_systime_parameters = {
                 "slope": slope,
                 "intercept": intercept,
+                "wrap_sample_indices": wrap_sample_indices,
             }
         else:
             slope = self.regressed_systime_parameters["slope"]
             intercept = self.regressed_systime_parameters["intercept"]
+            wrap_sample_indices = self.regressed_systime_parameters.get(
+                "wrap_sample_indices", np.empty(0, dtype=np.int64)
+            )
+            # number of wraps before this slice's first global sample, plus any
+            # wrap occurring within the slice, recovers the global axis.
+            prior_wraps = int(
+                np.searchsorted(wrap_sample_indices, global_start, side="right")
+            )
+            trodestime_index = (
+                _unwrap_uint32(trodestime) + prior_wraps * UINT32_WRAP
+            ).astype(np.float64)
         adjusted_timestamps = intercept + slope * trodestime_index
         return (adjusted_timestamps) / NANOSECONDS_PER_SECOND
 
@@ -1224,6 +1285,9 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         self.selected_streams = full_io.selected_streams
         self._generate_minimal_annotations()
         self.regressed_systime_parameters = full_io.regressed_systime_parameters
+        # this partial starts at start_index within the full recording; anchor
+        # the timestamp unwrap to the same global axis as the full-file fit.
+        self._global_sample_offset = start_index
 
         # crop key information to range of interest
         header_size = None

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -46,7 +46,9 @@ def test_unwrap_multiple_wraps_is_monotonic():
     np.testing.assert_array_equal(out, true)
 
 
-@pytest.mark.parametrize("v", [np.array([], dtype=np.uint32), np.array([7], dtype=np.uint32)])
+@pytest.mark.parametrize(
+    "v", [np.array([], dtype=np.uint32), np.array([7], dtype=np.uint32)]
+)
 def test_unwrap_short_arrays(v):
     np.testing.assert_array_equal(_unwrap_uint32(v), v.astype(np.int64))
 

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -128,3 +128,55 @@ def test_non_wrapping_session_is_unchanged():
 
     np.testing.assert_allclose(out, true / FS, rtol=0, atol=1e-9)
     assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == []
+
+
+def _fit_then_partial(raw, systime_ns, start, stop):
+    """Fit on the full recording, then read a [start, stop) partial that inherits
+    the fit (mirrors how split iterators are created)."""
+    full = _make_io(raw, systime_ns)
+    full.get_regressed_systime(0, None)  # fit; populates wrap_sample_indices
+    partial = _make_io(
+        raw[start:stop],
+        systime_ns[start:stop],  # unused once params are set, kept aligned
+        global_offset=start,
+        params=full.regressed_systime_parameters,
+    )
+    return partial.get_regressed_systime(0, None)
+
+
+def test_partial_straddling_the_wrap():
+    # a partial that *contains* the wrap: prior_wraps == 0, but the in-slice
+    # _unwrap_uint32 must detect the jump.
+    raw, systime_ns, expected = _wrapping_session()  # wrap at sample 500
+    out = _fit_then_partial(raw, systime_ns, 450, 650)
+    np.testing.assert_allclose(out, expected[450:650], rtol=0, atol=1e-6)
+
+
+def test_partial_starting_exactly_on_the_wrap():
+    # start == wrap_sample_index (500): the single case that distinguishes
+    # searchsorted side="right" (correct) from side="left" (off by one wrap).
+    raw, systime_ns, expected = _wrapping_session()
+    out = _fit_then_partial(raw, systime_ns, 500, 700)
+    np.testing.assert_allclose(out, expected[500:700], rtol=0, atol=1e-6)
+
+
+def _multi_wrap_session(n=300):
+    # large per-sample step so the counter wraps several times within n samples
+    step = UINT32_WRAP // 100
+    true = np.arange(n, dtype=np.int64) * step
+    raw = (true % UINT32_WRAP).astype(np.uint32)
+    systime_ns = true.astype(np.float64) * 1e9 / FS
+    return raw, systime_ns, true / FS
+
+
+def test_multi_wrap_full_and_partial():
+    raw, systime_ns, expected = _multi_wrap_session()  # ~2 wraps within the file
+    full = _make_io(raw, systime_ns)
+    out_full = full.get_regressed_systime(0, None)
+    assert np.all(np.diff(out_full) > 0)
+    np.testing.assert_allclose(out_full, expected, rtol=0, atol=1e-6)
+    assert len(full.regressed_systime_parameters["wrap_sample_indices"]) >= 2
+
+    # a partial after several wraps (prior_wraps == 2) must land on the same axis
+    out = _fit_then_partial(raw, systime_ns, 250, 300)
+    np.testing.assert_allclose(out, expected[250:300], rtol=0, atol=1e-6)

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -1,0 +1,128 @@
+"""uint32 Trodes-timestamp wrap handling in get_regressed_systime (#169).
+
+The Trodes per-packet timestamp is a uint32 sample counter that rolls over after
+2**32 samples (~39.77 h at 30 kHz). Casting it to float and regressing system
+time on it used to produce silently corrupt (non-monotonic) timestamps once a
+recording crossed the wrap. These tests cover the unwrap helper, the full-file
+fit across a wrap, and -- the subtle part -- that a post-wrap *partial* iterator
+(which inherits the full-file fit) lands on the same global time axis.
+"""
+
+import numpy as np
+import pytest
+
+from trodes_to_nwb.spike_gadgets_raw_io import (
+    UINT32_WRAP,
+    SpikeGadgetsRawIO,
+    _unwrap_uint32,
+)
+
+FS = 30000.0  # Hz
+
+
+# --------------------------------------------------------------------------- #
+# _unwrap_uint32
+# --------------------------------------------------------------------------- #
+def test_unwrap_no_wrap_is_identity():
+    v = np.array([10, 11, 12, 20], dtype=np.uint32)
+    np.testing.assert_array_equal(_unwrap_uint32(v), [10, 11, 12, 20])
+
+
+def test_unwrap_single_wrap():
+    v = np.array([UINT32_WRAP - 2, UINT32_WRAP - 1, 0, 1], dtype=np.uint32)
+    np.testing.assert_array_equal(
+        _unwrap_uint32(v),
+        [UINT32_WRAP - 2, UINT32_WRAP - 1, UINT32_WRAP, UINT32_WRAP + 1],
+    )
+
+
+def test_unwrap_multiple_wraps_is_monotonic():
+    # a monotone counter with a large per-sample step so it wraps several times
+    # within a small array (sample 5 crosses 2**32, sample 9 crosses 2*2**32)
+    true = np.arange(12, dtype=np.int64) * 10**9
+    wrapped = (true % UINT32_WRAP).astype(np.uint32)
+    out = _unwrap_uint32(wrapped)
+    assert np.all(np.diff(out) > 0)
+    np.testing.assert_array_equal(out, true)
+
+
+@pytest.mark.parametrize("v", [np.array([], dtype=np.uint32), np.array([7], dtype=np.uint32)])
+def test_unwrap_short_arrays(v):
+    np.testing.assert_array_equal(_unwrap_uint32(v), v.astype(np.int64))
+
+
+# --------------------------------------------------------------------------- #
+# get_regressed_systime through a wrap
+# --------------------------------------------------------------------------- #
+def _make_io(raw, systime_ns, global_offset=0, params=None):
+    """Build a bare SpikeGadgetsRawIO wired to fixed timestamp/sysclock arrays."""
+    io = SpikeGadgetsRawIO.__new__(SpikeGadgetsRawIO)
+    io.regressed_systime_parameters = {} if params is None else params
+    io._global_sample_offset = global_offset
+
+    def _ts(i_start, i_stop):
+        stop = len(raw) if i_stop is None else i_stop
+        return raw[i_start:stop]
+
+    def _sys(i_start, i_stop):
+        stop = len(systime_ns) if i_stop is None else i_stop
+        return systime_ns[i_start:stop]
+
+    io.get_analogsignal_timestamps = _ts
+    io.get_sys_clock = _sys
+    return io
+
+
+def _wrapping_session(n=1000, wrap_at=500):
+    """A recording whose uint32 counter wraps at sample `wrap_at`."""
+    true = (UINT32_WRAP - wrap_at) + np.arange(n, dtype=np.int64)  # global monotone
+    raw = (true % UINT32_WRAP).astype(np.uint32)
+    systime_ns = true.astype(np.float64) * 1e9 / FS
+    expected_seconds = true / FS
+    return raw, systime_ns, expected_seconds
+
+
+def test_full_file_regression_recovers_monotonic_time_across_wrap():
+    raw, systime_ns, expected = _wrapping_session()
+    io = _make_io(raw, systime_ns)
+
+    out = io.get_regressed_systime(0, None)
+
+    assert np.all(np.diff(out) > 0), "regressed time must be monotonic across the wrap"
+    np.testing.assert_allclose(out, expected, rtol=0, atol=1e-6)
+    # a wrap was recorded for partial iterators to use
+    assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == [500]
+
+
+def test_partial_after_wrap_lands_on_same_axis_as_full():
+    raw, systime_ns, expected = _wrapping_session()
+    full = _make_io(raw, systime_ns)
+    full.get_regressed_systime(0, None)  # fit; populates wrap_sample_indices
+
+    # a partial iterator covering a post-wrap sub-range [600, 800) inherits the
+    # fitted params and reads only its (small, post-wrap) raw counter values
+    start, stop = 600, 800
+    partial = _make_io(
+        raw[start:stop],
+        systime_ns[start:stop],  # unused (params already set) but keep aligned
+        global_offset=start,
+        params=full.regressed_systime_parameters,
+    )
+
+    out = partial.get_regressed_systime(0, None)
+
+    np.testing.assert_allclose(out, expected[start:stop], rtol=0, atol=1e-6)
+
+
+def test_non_wrapping_session_is_unchanged():
+    # sanity: without a wrap, behaviour matches a plain float regression
+    n = 500
+    true = 1_000 + np.arange(n, dtype=np.int64)
+    raw = true.astype(np.uint32)
+    systime_ns = true.astype(np.float64) * 1e9 / FS
+    io = _make_io(raw, systime_ns)
+
+    out = io.get_regressed_systime(0, None)
+
+    np.testing.assert_allclose(out, true / FS, rtol=0, atol=1e-9)
+    assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == []


### PR DESCRIPTION
Fixes #169.

## Problem
`get_regressed_systime` regresses system time on the Trodes timestamp and cast
the **uint32** sample counter to `float64` *before* `linregress`. When a
recording crosses the counter's `2**32` wrap (~39.77 h at 30 kHz), the regressor
input contains a ~4.3e9 backward jump that destroys the linear fit, silently
producing non-monotonic timestamps with errors of up to ~39 h — affecting both
the ephys ElectricalSeries and position.

(Verified by simulation earlier: a 40 h recording produced non-monotonic output
with ~1.4e5 s max error; 30 h was fine.)

## Fix
Unwrap the counter to a globally monotonic `int64` axis (add `2**32` at/after
each wrap), anchored at the **full recording's sample 0**. The subtle part is
that any wrap-spanning recording is *also* split into partial (>30 min)
iterators, which inherit the full-file fit (`slope`/`intercept`) and read a
post-wrap sub-range of small raw values. To keep them on the same axis:

- the fitting call records the **global sample index of every wrap** in
  `regressed_systime_parameters["wrap_sample_indices"]`;
- each iterator carries a `_global_sample_offset` (`0` for a full file,
  `start_index` for a partial) and adds `(# wraps before its global start) *
  2**32` to its unwrapped sub-range.

I worked through the wrap-at-boundary and wrap-within-partial cases: each wrap is
counted exactly once, and a partial's unwrapped axis equals the full-file axis at
the same global sample. For **non-wrapping** recordings the unwrap is a no-op, so
behaviour is byte-identical to before (zero risk to the common path).

### Illustration

<img width="5002" height="1837" alt="uint32_wrap_illustration" src="https://github.com/user-attachments/assets/38607f04-32e5-4307-8a74-3085a5f810ff" />

A simulated 42 h / 30 kHz recording crossing the 2³² sample wrap once.
**(a)** Fitting `linregress(trodestime, sysClock)` on the raw **wrapped** uint32
counter: post-wrap samples fold back to small counter values and corrupt the fit.
**(b)** Fitting on the **unwrapped** int64 counter (this PR): a single clean band.
**(c)** Reconstructed timestamps — *before* jumps ~40 h backward at the wrap
(non-monotonic, max error ≈ 33 h); *after* tracks true time (max error ≈ 2×10⁻⁵ s).




## Tests
`test_timestamp_wrap.py`: the `_unwrap_uint32` helper (no/one/many wraps, short
arrays); the full-file regression recovering monotonic, accurate time across a
wrap; a post-wrap **partial** iterator landing on the same axis as the full file;
and the unchanged non-wrapping case. Existing `test_spikegadgets_io.py`,
`test_convert_ephys.py`, `test_convert_intervals.py` still pass.

## Notes
- Scope is the PTP/sysClock regression path (`get_regressed_systime`). The
  non-PTP `get_systime_from_trodes_timestamps` path is a separate, lower-impact
  concern.
- The OLS fit's lack of robustness to a single bad sysClock sample (noted in the
  issue) is **not** addressed here and remains a follow-up.
- Branch name says "guard" for historical reasons; this PR implements the full
  unwrap, not a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
