### PR TITLE
Harden timestamp/position integrity: ephys guard + PTP edge cases (#172)

### DIFF
--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -216,10 +216,14 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             )
 
         logger.info("Reading timestamps COMPLETE")
-        is_timestamps_sequential = np.all(np.diff(self.timestamps))
+        # Must be strictly increasing. `np.all(np.diff(...))` only checks that no
+        # two timestamps are *equal* (nonzero diff); it silently accepts a
+        # backward jump (negative diff), which is exactly what a clock reset or
+        # an out-of-order file concatenation would produce. Check for > 0.
+        is_timestamps_sequential = bool(np.all(np.diff(self.timestamps) > 0))
         if not is_timestamps_sequential:
             warn(
-                "Timestamps are not sequential. This may cause problems with some software or data analysis.",
+                "Timestamps are not strictly increasing. This may cause problems with some software or data analysis.",
                 stacklevel=2,
             )
 

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -637,12 +637,14 @@ def _get_position_timestamps_ptp(
         logger.warning(
             "PTP timestamps correspond to a time earlier than 2000. This may be due to a PTP clock reset."
         )
-    # Downstream consumers (e.g. Spyglass) assume monotonically increasing
-    # position timestamps; warn rather than silently writing a backward jump.
-    if not ptp_timestamps.is_monotonic_increasing:
+    # Downstream consumers (e.g. Spyglass) assume strictly increasing position
+    # timestamps; warn rather than silently writing a backward jump or a stalled
+    # (duplicate) timestamp. `is_monotonic_increasing` is non-strict, so check
+    # diffs > 0 to also catch duplicates, matching the ephys guard.
+    if ptp_timestamps.size > 1 and not np.all(np.diff(ptp_timestamps.values) > 0):
         logger.warning(
-            "PTP timestamps are not monotonically increasing. This may be due to "
-            "a PTP clock reset and can break downstream epoch/position handling."
+            "PTP timestamps are not strictly increasing. This may be due to a "
+            "PTP clock reset and can break downstream epoch/position handling."
         )
 
     video_timestamps = video_timestamps.drop(
@@ -682,19 +684,28 @@ def _get_position_timestamps_ptp(
 
     # Video frames with no matching position tracking (the camera can keep
     # running after online/offline tracking stops) arrive from the upstream
-    # left-merge as NaN x/y. Drop them so they are not written as
-    # valid-timestamped NaN positions. The non-PTP path filters these
-    # incidentally; the PTP path did not. Bookkeeping columns are never NaN.
-    bookkeeping = {"video_frame_ind", "non_repeat_timestamp_labels"}
-    position_columns = [c for c in video_timestamps.columns if c not in bookkeeping]
+    # left-merge as NaN for every position column. Drop ONLY those fully
+    # unmatched frames: rows where just one LED is missing, or interior
+    # single-frame dropouts, are preserved so trajectories are not silently
+    # elided. (The non-PTP path removes unmatched frames separately, by
+    # sample-count membership, not by NaN.)
+    position_columns = [
+        c for c in ("xloc", "yloc", "xloc2", "yloc2") if c in video_timestamps.columns
+    ]
     if position_columns:
-        n_missing = int(video_timestamps[position_columns].isna().any(axis=1).sum())
-        if n_missing:
-            logger.warning(
-                f"Dropping {n_missing} PTP video frame(s) with no matching "
-                "position tracking (NaN position)."
+        unmatched = video_timestamps[position_columns].isna().all(axis=1)
+        if unmatched.any():
+            dropped_frames = (
+                video_timestamps.loc[unmatched, "video_frame_ind"].tolist()
+                if "video_frame_ind" in video_timestamps.columns
+                else "unknown"
             )
-            video_timestamps = video_timestamps.dropna(subset=position_columns)
+            logger.warning(
+                f"Dropping {int(unmatched.sum())} PTP video frame(s) with no "
+                "matching position tracking (all position columns NaN); "
+                f"video_frame_ind={dropped_frames}."
+            )
+            video_timestamps = video_timestamps[~unmatched]
 
     return video_timestamps
 

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -637,21 +637,37 @@ def _get_position_timestamps_ptp(
         logger.warning(
             "PTP timestamps correspond to a time earlier than 2000. This may be due to a PTP clock reset."
         )
+    # Downstream consumers (e.g. Spyglass) assume monotonically increasing
+    # position timestamps; warn rather than silently writing a backward jump.
+    if not ptp_timestamps.is_monotonic_increasing:
+        logger.warning(
+            "PTP timestamps are not monotonically increasing. This may be due to "
+            "a PTP clock reset and can break downstream epoch/position handling."
+        )
 
     video_timestamps = video_timestamps.drop(
         columns=["HWframeCount", "HWTimestamp"]
     ).set_index(ptp_timestamps)
 
-    # Ignore positions before the timing pause.
-    pause_mid_ind = (
-        np.nonzero(
-            np.logical_and(
-                np.diff(video_timestamps.index[:100]) > DEFAULT_MIN_PTP_PAUSE_S,
-                np.diff(video_timestamps.index[:100]) < DEFAULT_MAX_PTP_PAUSE_S,
-            )
-        )[0][0]
-        + 1
-    )
+    # Ignore positions before the timing pause. If no pause is found in the first
+    # 100 frames, keep all frames (mirrors the guarded non-PTP path) rather than
+    # aborting the whole conversion with an IndexError.
+    try:
+        pause_mid_ind = (
+            np.nonzero(
+                np.logical_and(
+                    np.diff(video_timestamps.index[:100]) > DEFAULT_MIN_PTP_PAUSE_S,
+                    np.diff(video_timestamps.index[:100]) < DEFAULT_MAX_PTP_PAUSE_S,
+                )
+            )[0][0]
+            + 1
+        )
+    except IndexError:
+        logger.warning(
+            "No acquisition timing pause found in the first 100 PTP frames; "
+            "keeping all frames."
+        )
+        pause_mid_ind = 0
     video_timestamps = video_timestamps.iloc[pause_mid_ind:]
     if len(video_timestamps.index) > 1:
         frame_rate = 1 / np.median(np.diff(video_timestamps.index))
@@ -663,6 +679,22 @@ def _get_position_timestamps_ptp(
         logger.warning(
             "Less than 2 timestamps remain after PTP pause removal; cannot estimate frame rate."
         )
+
+    # Video frames with no matching position tracking (the camera can keep
+    # running after online/offline tracking stops) arrive from the upstream
+    # left-merge as NaN x/y. Drop them so they are not written as
+    # valid-timestamped NaN positions. The non-PTP path filters these
+    # incidentally; the PTP path did not. Bookkeeping columns are never NaN.
+    bookkeeping = {"video_frame_ind", "non_repeat_timestamp_labels"}
+    position_columns = [c for c in video_timestamps.columns if c not in bookkeeping]
+    if position_columns:
+        n_missing = int(video_timestamps[position_columns].isna().any(axis=1).sum())
+        if n_missing:
+            logger.warning(
+                f"Dropping {n_missing} PTP video frame(s) with no matching "
+                "position tracking (NaN position)."
+            )
+            video_timestamps = video_timestamps.dropna(subset=position_columns)
 
     return video_timestamps
 

--- a/src/trodes_to_nwb/tests/test_position_ptp_integrity.py
+++ b/src/trodes_to_nwb/tests/test_position_ptp_integrity.py
@@ -1,0 +1,71 @@
+"""PTP position-timestamp robustness for ``_get_position_timestamps_ptp`` (#172).
+
+Covers three failure modes that the PTP path previously handled poorly:
+- (c) no acquisition pause in the first 100 frames -> used to raise IndexError
+      and abort the whole conversion; should now keep all frames;
+- (b) non-monotonic PTP timestamps -> used to be written silently; should warn;
+- (d) trailing NaN positions (video runs past tracking) -> used to be written as
+      valid-timestamped NaN; should be dropped.
+"""
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from trodes_to_nwb.convert_position import _get_position_timestamps_ptp
+
+FS = 30.0  # camera frames/s
+EPOCH_2023 = 1.7e9  # seconds, ~2023 (avoids the <2000 warning path)
+LOGGER = logging.getLogger("convert")
+
+
+def _ptp_df(seconds, xloc=None, yloc=None):
+    """Build the merged frame the PTP helper expects (HWTimestamp in ns)."""
+    n = len(seconds)
+    data = {
+        "HWframeCount": np.arange(n),
+        "HWTimestamp": (np.asarray(seconds) * 1e9).astype(np.int64),
+        "video_frame_ind": np.arange(n),
+        "non_repeat_timestamp_labels": np.ones(n, dtype=int),
+    }
+    if xloc is not None:
+        data["xloc"] = np.asarray(xloc, dtype=float)
+    if yloc is not None:
+        data["yloc"] = np.asarray(yloc, dtype=float)
+    return pd.DataFrame(data)
+
+
+def test_no_pause_keeps_all_frames_without_raising():
+    seconds = EPOCH_2023 + np.arange(200) / FS  # uniform, no acquisition pause
+    out = _get_position_timestamps_ptp(_ptp_df(seconds), LOGGER)
+    assert len(out) == 200  # would previously have raised IndexError
+
+
+def test_pause_is_still_removed_when_present():
+    seconds = EPOCH_2023 + np.arange(200) / FS
+    seconds[10:] += 0.6  # a 0.6 s pause between frames 9 and 10 (within 0.4-2.0 s)
+    out = _get_position_timestamps_ptp(_ptp_df(seconds), LOGGER)
+    assert len(out) == 200 - 10
+
+
+def test_non_monotonic_timestamps_warn(caplog):
+    seconds = EPOCH_2023 + np.arange(50) / FS
+    seconds[30] -= 10.0  # backward jump
+    with caplog.at_level(logging.WARNING, logger="convert"):
+        _get_position_timestamps_ptp(_ptp_df(seconds), LOGGER)
+    assert any("monotonic" in r.message.lower() for r in caplog.records)
+
+
+def test_trailing_nan_positions_are_dropped(caplog):
+    n = 20
+    seconds = EPOCH_2023 + np.arange(n) / FS  # no pause -> all frames retained
+    xloc = np.arange(n, dtype=float)
+    yloc = np.arange(n, dtype=float)
+    xloc[-2:] = np.nan  # camera ran two frames past position tracking
+    yloc[-2:] = np.nan
+    with caplog.at_level(logging.WARNING, logger="convert"):
+        out = _get_position_timestamps_ptp(_ptp_df(seconds, xloc, yloc), LOGGER)
+    assert int(out[["xloc", "yloc"]].isna().sum().sum()) == 0
+    assert len(out) == n - 2
+    assert any("no matching" in r.message.lower() for r in caplog.records)

--- a/src/trodes_to_nwb/tests/test_position_ptp_integrity.py
+++ b/src/trodes_to_nwb/tests/test_position_ptp_integrity.py
@@ -54,7 +54,7 @@ def test_non_monotonic_timestamps_warn(caplog):
     seconds[30] -= 10.0  # backward jump
     with caplog.at_level(logging.WARNING, logger="convert"):
         _get_position_timestamps_ptp(_ptp_df(seconds), LOGGER)
-    assert any("monotonic" in r.message.lower() for r in caplog.records)
+    assert any("strictly increasing" in r.message.lower() for r in caplog.records)
 
 
 def test_trailing_nan_positions_are_dropped(caplog):
@@ -69,3 +69,17 @@ def test_trailing_nan_positions_are_dropped(caplog):
     assert int(out[["xloc", "yloc"]].isna().sum().sum()) == 0
     assert len(out) == n - 2
     assert any("no matching" in r.message.lower() for r in caplog.records)
+
+
+def test_partial_nan_rows_are_preserved():
+    # Only fully-unmatched rows (every position column NaN) are dropped. A row
+    # where one column is NaN but another is valid must be kept, so a real
+    # single-LED dropout (or interior gap) is not silently elided.
+    n = 20
+    seconds = EPOCH_2023 + np.arange(n) / FS
+    xloc = np.arange(n, dtype=float)
+    yloc = np.arange(n, dtype=float)
+    xloc[5] = np.nan  # interior, single-column NaN -> row is NOT fully unmatched
+    xloc[-1] = np.nan
+    out = _get_position_timestamps_ptp(_ptp_df(seconds, xloc, yloc), LOGGER)
+    assert len(out) == n  # nothing dropped; yloc still present on those rows


### PR DESCRIPTION
Fixes #172.

Four related timestamp/position-integrity fixes so silent or edge-case problems
fail gracefully instead of corrupting output or aborting a run.

### (a) ephys "sequential timestamps" guard — `convert_ephys.py`
`is_timestamps_sequential = np.all(np.diff(self.timestamps))` only rejects
*equal* timestamps (nonzero diff); a **backward** jump (negative diff) passed
silently. Changed to `np.all(np.diff(self.timestamps) > 0)` and updated the
warning text.

### (b) PTP timestamps monotonicity — `convert_position.py`
PTP timestamps were written with no monotonicity check. Added a warning when
they are not strictly increasing (Spyglass and other consumers assume monotonic
position time).

### (c) PTP acquisition-pause IndexError — `convert_position.py`
`_get_position_timestamps_ptp` did `np.nonzero(...)[0][0]` with no guard, raising
`IndexError` and aborting the whole conversion when no 0.4–2.0 s pause exists in
the first 100 frames. The non-PTP path already guards this; mirror it (keep all
frames + warn).

### (d) PTP trailing NaN positions — `convert_position.py`
Frames with no matching position tracking (the camera can run past when tracking
stops) arrive from the upstream left-merge as NaN x/y and were written as
valid-timestamped NaN. Drop them (with a warning). The non-PTP path filtered
these incidentally; the PTP path did not.

## Tests
`test_position_ptp_integrity.py` covers (b) the monotonicity warning, (c)
no-pause keeps all frames without raising (and pause removal still works when a
pause is present), and (d) trailing NaN positions are dropped. Existing
`test_convert_position.py` (PTP + non-PTP) and `test_convert_ephys.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
