### PR TITLE
Gate conversion on validation via a strict flag (default True) (#173)

### DIFF
--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -230,8 +230,8 @@ def create_nwbs(
         files, by default False.
     strict : bool, optional
         If True (default), stop the conversion of a session when its metadata
-        fails schema validation or when NWB Inspector reports CRITICAL/ERROR
-        issues (which block DANDI upload). If False, log those problems and write
+        fails schema validation or when NWB Inspector reports DANDI-blocking
+        issues (ERROR/CRITICAL/pynwb-validation). If False, log those problems and write
         the file anyway (the previous behavior).
 
     """
@@ -454,7 +454,7 @@ def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger, strict: bool = True
     required for upload to the DANDI archive.
 
     If ``strict`` is True (default), raise a ``ValueError`` when the inspector
-    reports any CRITICAL or ERROR issue (which block DANDI upload), so the
+    reports any DANDI-blocking issue (ERROR, CRITICAL, or pynwb-validation), so the
     session is marked failed rather than silently producing an invalid file.
     Best-practice violations and suggestions are always reported but never
     raise."""
@@ -522,19 +522,25 @@ def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger, strict: bool = True
         f"Please see {str(Path(report_file_path).absolute())} for the full NWB Inspector report"
     )
 
-    # Gate the conversion on DANDI-blocking issues. CRITICAL/ERROR importances
-    # prevent DANDI upload, so by default fail the session rather than silently
-    # report success on an invalid file. Best-practice violations/suggestions are
-    # reported above but never block.
-    gating_levels = (
-        nwbinspector.Importance.CRITICAL,
+    # Gate the conversion on DANDI-blocking issues. ERROR and CRITICAL
+    # importances prevent DANDI upload, as does PYNWB_VALIDATION (an actual pynwb
+    # schema-validation failure, which inspect_nwbfile runs by default and which
+    # sits between ERROR and CRITICAL in severity). Best-practice
+    # violations/suggestions are reported above but never block. By default fail
+    # the session rather than silently reporting success on an invalid file.
+    gating_levels = [
         nwbinspector.Importance.ERROR,
-    )
+        nwbinspector.Importance.CRITICAL,
+    ]
+    # PYNWB_VALIDATION was added in newer nwbinspector; include it if present.
+    pynwb_validation = getattr(nwbinspector.Importance, "PYNWB_VALIDATION", None)
+    if pynwb_validation is not None:
+        gating_levels.append(pynwb_validation)
     gating_messages = [m for m in messages if m.importance in gating_levels]
     if gating_messages and strict:
         raise ValueError(
-            f"NWB Inspector found {len(gating_messages)} CRITICAL/ERROR issue(s) "
-            "that block DANDI upload. See the report at "
+            f"NWB Inspector found {len(gating_messages)} issue(s) that block "
+            f"DANDI upload (ERROR/CRITICAL/pynwb-validation). See the report at "
             f"{Path(report_file_path).absolute()}. Pass strict=False to "
             "create_nwbs to write the file anyway."
         )

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -196,6 +196,7 @@ def create_nwbs(
     query_expression: str | None = None,
     disable_ptp: bool = False,
     behavior_only: bool = False,
+    strict: bool = True,
 ):
     """
     Convert SpikeGadgets data to NWB format.
@@ -227,6 +228,11 @@ def create_nwbs(
     behavior_only : bool, optional
         Flag to indicate only behaviorsl data (no ephys) was collected in the rec
         files, by default False.
+    strict : bool, optional
+        If True (default), stop the conversion of a session when its metadata
+        fails schema validation or when NWB Inspector reports CRITICAL/ERROR
+        issues (which block DANDI upload). If False, log those problems and write
+        the file anyway (the previous behavior).
 
     """
 
@@ -258,6 +264,7 @@ def create_nwbs(
                     fs_gui_dir,
                     disable_ptp,
                     behavior_only=behavior_only,
+                    strict=strict,
                 )
                 return True
             except Exception as e:
@@ -288,6 +295,7 @@ def create_nwbs(
                 fs_gui_dir,
                 disable_ptp,
                 behavior_only=behavior_only,
+                strict=strict,
             )
 
 
@@ -302,6 +310,7 @@ def _create_nwb(
     fs_gui_dir: str = "",
     disable_ptp: bool = False,
     behavior_only: bool = False,
+    strict: bool = True,
 ):
     # create loggers
     logger = setup_logger("convert", f"{session[1]}{session[0]}_convert.log")
@@ -340,7 +349,9 @@ def _create_nwb(
     logger.info(f"\tmetadata_filepath: {metadata_filepaths}")
 
     metadata, device_metadata = load_metadata(
-        metadata_filepaths, device_metadata_paths=device_metadata_paths
+        metadata_filepaths,
+        device_metadata_paths=device_metadata_paths,
+        strict=strict,
     )
 
     logger.info("CREATING HARDWARE MAPS")
@@ -431,16 +442,22 @@ def _create_nwb(
 
     # run NWB Inspector to validate file for best practices before upload to DANDI
     logger.info("RUNNING NWB INSPECTOR")
-    _inspect_nwb(output_path, logger)
+    _inspect_nwb(output_path, logger, strict=strict)
 
     logger.info("DONE")
 
     return output_path
 
 
-def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger):
+def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger, strict: bool = True):
     """Run the resulting NWB file through the NWB Inspector to ensure it passes validation checks
-    required for upload to the DANDI archive."""
+    required for upload to the DANDI archive.
+
+    If ``strict`` is True (default), raise a ``ValueError`` when the inspector
+    reports any CRITICAL or ERROR issue (which block DANDI upload), so the
+    session is marked failed rather than silently producing an invalid file.
+    Best-practice violations and suggestions are always reported but never
+    raise."""
     # this may take some time
     messages = list(
         nwbinspector.inspect_nwbfile(
@@ -504,3 +521,20 @@ def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger):
     print(
         f"Please see {str(Path(report_file_path).absolute())} for the full NWB Inspector report"
     )
+
+    # Gate the conversion on DANDI-blocking issues. CRITICAL/ERROR importances
+    # prevent DANDI upload, so by default fail the session rather than silently
+    # report success on an invalid file. Best-practice violations/suggestions are
+    # reported above but never block.
+    gating_levels = (
+        nwbinspector.Importance.CRITICAL,
+        nwbinspector.Importance.ERROR,
+    )
+    gating_messages = [m for m in messages if m.importance in gating_levels]
+    if gating_messages and strict:
+        raise ValueError(
+            f"NWB Inspector found {len(gating_messages)} CRITICAL/ERROR issue(s) "
+            "that block DANDI upload. See the report at "
+            f"{Path(report_file_path).absolute()}. Pass strict=False to "
+            "create_nwbs to write the file anyway."
+        )

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -479,11 +479,18 @@ def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger, strict: bool = True
         f"NWB Inspector report saved to {str(Path(report_file_path).absolute())}!"
     )
 
+    # PYNWB_VALIDATION was added in newer nwbinspector; include it if present so
+    # the console summary below and the DANDI-blocking gate further down agree on
+    # what counts as a blocking issue.
+    pynwb_validation = getattr(nwbinspector.Importance, "PYNWB_VALIDATION", None)
+
     flagged_error_levels = [
         nwbinspector.Importance.ERROR,
         nwbinspector.Importance.BEST_PRACTICE_VIOLATION,
         nwbinspector.Importance.CRITICAL,
     ]
+    if pynwb_validation is not None:
+        flagged_error_levels.append(pynwb_validation)
     critical_errors = list(
         filter(lambda x: x.importance in flagged_error_levels, messages)
     )
@@ -532,8 +539,6 @@ def _inspect_nwb(nwbfile_path: Path, logger: logging.Logger, strict: bool = True
         nwbinspector.Importance.ERROR,
         nwbinspector.Importance.CRITICAL,
     ]
-    # PYNWB_VALIDATION was added in newer nwbinspector; include it if present.
-    pynwb_validation = getattr(nwbinspector.Importance, "PYNWB_VALIDATION", None)
     if pynwb_validation is not None:
         gating_levels.append(pynwb_validation)
     gating_messages = [m for m in messages if m.importance in gating_levels]

--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -33,6 +33,7 @@ from trodes_to_nwb import __version__
 def load_metadata(
     metadata_path: str,
     device_metadata_paths: list[str],
+    strict: bool = True,
 ) -> tuple[dict, list[dict]]:
     """Loads metadata files as dictionaries.
 
@@ -43,11 +44,21 @@ def load_metadata(
     device_metadata_paths : list[str]
         List of paths to yaml files with information on standard devices (e.g. probes,
         optical fibers, viruses).
+    strict : bool, optional
+        If True (default), raise a ``ValueError`` when the metadata fails schema
+        validation, so the conversion stops before building a file from invalid
+        metadata. If False, log the validation errors and continue (the previous
+        behavior), which is useful for debugging.
 
     Returns
     -------
     tuple[dict, list[dict]]
         The yaml generator metadata and list of device metadatas.
+
+    Raises
+    ------
+    ValueError
+        If ``strict`` is True and the metadata fails schema validation.
     """
     metadata = None
     with open(metadata_path) as stream:
@@ -58,7 +69,13 @@ def load_metadata(
     ) = trodes_to_nwb.metadata_validation.validate(metadata)
     if not is_metadata_valid:
         logger = logging.getLogger("convert")
-        logger.exception("".join(metadata_errors))
+        message = (
+            f"Metadata file {metadata_path} failed validation against "
+            "nwb_schema.json:\n" + "\n".join(metadata_errors)
+        )
+        if strict:
+            raise ValueError(message)
+        logger.error(message)
     device_metadata = []
     for path in device_metadata_paths:
         with open(path) as stream:

--- a/src/trodes_to_nwb/metadata_validation.py
+++ b/src/trodes_to_nwb/metadata_validation.py
@@ -53,16 +53,20 @@ def validate(metadata: dict) -> tuple:
     assert isinstance(metadata, dict)  # cannot proceed if metadata is not a dictionary
 
     # date_of_birth is set to a datetime by the YAML-to-dict converter.
-    # This code converts date_of_birth  to string
+    # This code converts date_of_birth to an ISO-8601 string for schema checking.
     metadata_content = copy.deepcopy(metadata) or {}
     if (
         metadata_content["subject"]
         and metadata_content["subject"]["date_of_birth"]
         and type(metadata_content["subject"]["date_of_birth"]) is datetime.datetime
     ):
-        metadata_content["subject"]["date_of_birth"] = (
-            metadata_content["subject"]["date_of_birth"].utcnow().isoformat()
-        )
+        # NOTE: use the instance's own value. `datetime.utcnow()` is a classmethod
+        # that ignores the instance and returns the current time, so the previous
+        # `.utcnow().isoformat()` validated *today's* date instead of the subject's
+        # date of birth.
+        metadata_content["subject"]["date_of_birth"] = metadata_content["subject"][
+            "date_of_birth"
+        ].isoformat()
 
     schema = _get_json_schema()
     validator = jsonschema.Draft202012Validator(schema)

--- a/src/trodes_to_nwb/metadata_validation.py
+++ b/src/trodes_to_nwb/metadata_validation.py
@@ -55,18 +55,21 @@ def validate(metadata: dict) -> tuple:
     # date_of_birth is set to a datetime by the YAML-to-dict converter.
     # This code converts date_of_birth to an ISO-8601 string for schema checking.
     metadata_content = copy.deepcopy(metadata) or {}
+    # Use .get() so metadata missing `subject` (or a subject missing
+    # `date_of_birth`) is reported through the schema validator below rather than
+    # raising a KeyError here -- otherwise strict=True conversion would surface a
+    # bare KeyError instead of the schema-validation report.
+    subject = metadata_content.get("subject")
     if (
-        metadata_content["subject"]
-        and metadata_content["subject"]["date_of_birth"]
-        and type(metadata_content["subject"]["date_of_birth"]) is datetime.datetime
+        subject
+        and subject.get("date_of_birth")
+        and type(subject["date_of_birth"]) is datetime.datetime
     ):
         # NOTE: use the instance's own value. `datetime.utcnow()` is a classmethod
         # that ignores the instance and returns the current time, so the previous
         # `.utcnow().isoformat()` validated *today's* date instead of the subject's
         # date of birth.
-        metadata_content["subject"]["date_of_birth"] = metadata_content["subject"][
-            "date_of_birth"
-        ].isoformat()
+        subject["date_of_birth"] = subject["date_of_birth"].isoformat()
 
     schema = _get_json_schema()
     validator = jsonschema.Draft202012Validator(schema)

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 from pynwb import NWBHDF5IO
 
 from unittest.mock import MagicMock
@@ -109,26 +110,41 @@ def test_convert_full_with_inspector_error(mocker):
         os.makedirs(video_directory)
 
     exclude_reconfig_yaml = str(data_path / "20230622_sample_metadataProbeReconfig.yml")
-    create_nwbs(
-        path=data_path,
-        device_metadata_paths=device_metadata,
-        output_dir=str(data_path),
-        fs_gui_dir=data_path,
-        n_workers=1,
-        query_expression=f"animal == 'sample' and full_path != '{exclude_reconfig_yaml}'",
-    )
+    query = f"animal == 'sample' and full_path != '{exclude_reconfig_yaml}'"
 
     output_file_path = data_path / "sample20230622.nwb"
-
     output_report_path = data_path / "sample20230622_nwbinspector_report.txt"
-    assert os.path.isfile(output_report_path)
 
+    # Removing the Subject makes NWB Inspector report a CRITICAL issue
+    # (check_subject_exists). With strict=True (the default) this must fail the
+    # conversion rather than silently writing a DANDI-invalid file.
+    with pytest.raises(ValueError, match="CRITICAL/ERROR"):
+        create_nwbs(
+            path=data_path,
+            device_metadata_paths=device_metadata,
+            output_dir=str(data_path),
+            fs_gui_dir=data_path,
+            n_workers=1,
+            query_expression=query,
+        )
+
+    # The inspector report is still written (before the gate raises) and records
+    # the critical issue.
+    assert os.path.isfile(output_report_path)
     with open(output_report_path) as f:
         assert "Importance.CRITICAL: check_subject_exists" in f.read()
 
-    # TODO check that the error is printed to stdout
-    # 0.0  Importance.CRITICAL: check_subject_exists - 'NWBFile' object at location '/'
-    #    Message: Subject is missing.
+    # Escape hatch: strict=False writes the file anyway (previous behavior).
+    create_nwbs(
+        path=data_path,
+        device_metadata_paths=get_included_device_metadata_paths(),
+        output_dir=str(data_path),
+        fs_gui_dir=data_path,
+        n_workers=1,
+        query_expression=query,
+        strict=False,
+    )
+    assert os.path.isfile(output_file_path)
 
     # cleanup
     os.remove(output_file_path)

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -118,7 +118,7 @@ def test_convert_full_with_inspector_error(mocker):
     # Removing the Subject makes NWB Inspector report a CRITICAL issue
     # (check_subject_exists). With strict=True (the default) this must fail the
     # conversion rather than silently writing a DANDI-invalid file.
-    with pytest.raises(ValueError, match="CRITICAL/ERROR"):
+    with pytest.raises(ValueError, match="block DANDI upload"):
         create_nwbs(
             path=data_path,
             device_metadata_paths=device_metadata,

--- a/src/trodes_to_nwb/tests/test_convert_position.py
+++ b/src/trodes_to_nwb/tests/test_convert_position.py
@@ -306,9 +306,11 @@ def test_add_position_non_ptp():
     # make session_df
     path_df = get_file_info(data_path)
     session_df = path_df[(path_df.animal == "ginny")]
-    # get metadata
+    # get metadata. This non-PTP fixture predates the current schema and is
+    # missing a required `name`, so load it with strict=False: this test
+    # exercises position handling, not metadata validation.
     metadata_path = data_path / "nonptp_metadata.yml"
-    metadata, _ = convert_yaml.load_metadata(metadata_path, [])
+    metadata, _ = convert_yaml.load_metadata(metadata_path, [], strict=False)
     # load the prepped non-ptp nwbfile
     with NWBHDF5IO(data_path / "non_ptp_prep.nwb", "a", load_namespaces=True) as io:
         nwbfile = io.read()

--- a/src/trodes_to_nwb/tests/test_convert_yaml.py
+++ b/src/trodes_to_nwb/tests/test_convert_yaml.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from datetime import datetime
 
+import pytest
 from hdmf.common.table import DynamicTable, VectorData
 from ndx_franklab_novela import CameraDevice, Probe, Shank, ShanksElectrode
 from pynwb.file import ProcessingModule, Subject
@@ -12,6 +13,15 @@ from trodes_to_nwb.convert_position import add_associated_video_files
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
+
+
+def test_load_metadata_strict_raises_on_invalid(tmp_path):
+    # schema-invalid metadata: has a (null) subject so validate() doesn't itself
+    # KeyError, but is missing required top-level fields (lab, institution, ...)
+    bad = tmp_path / "20230101_bad_metadata.yml"
+    bad.write_text("subject:\nexperimenter_name:\n- Last\n- First\n")
+    with pytest.raises(ValueError, match="failed validation"):
+        convert_yaml.load_metadata(str(bad), [], strict=True)
 
 
 def test_initial_nwb_creation():

--- a/src/trodes_to_nwb/tests/test_metadata_validation.py
+++ b/src/trodes_to_nwb/tests/test_metadata_validation.py
@@ -21,3 +21,28 @@ def test_verify_validation_called(jsonValidator, getSchema):
     validate(basic_test_data)
     assert getSchema.call_count == 1
     assert jsonValidator.call_count == 1
+
+
+def test_validate_does_not_raise_when_subject_missing():
+    # Metadata with no ``subject`` key must be reported through the normal
+    # (is_valid, errors) channel, not crash validate() with a KeyError from the
+    # date_of_birth pre-processing. With strict=True conversion now raising on
+    # invalid metadata, a KeyError here would bypass the schema report entirely.
+    data = copy.deepcopy(test_metadata_dict_samples.basic_data)
+    del data["subject"]
+    is_valid, errors = validate(data)
+    # subject is not in the schema's required list, so the rest being valid
+    # leaves the metadata valid -- the point is that validate() does not raise.
+    assert is_valid is True
+    assert errors == []
+
+
+def test_validate_does_not_raise_when_date_of_birth_missing():
+    # A subject dict without date_of_birth must not crash the date_of_birth
+    # pre-processing; date_of_birth is required by the subject sub-schema, so it
+    # is reported as a normal validation error instead.
+    data = copy.deepcopy(test_metadata_dict_samples.basic_data)
+    data["subject"].pop("date_of_birth")
+    is_valid, errors = validate(data)
+    assert is_valid is False
+    assert any("date_of_birth" in error for error in errors)

--- a/src/trodes_to_nwb/update_electrodes.py
+++ b/src/trodes_to_nwb/update_electrodes.py
@@ -149,8 +149,12 @@ def build_electrodes_from_config(
     Assumes each ``hwChan`` value is unique across the electrodes table; this is
     the invariant the whole remap relies on and it is enforced here.
     """
+    # strict=False preserves this tool's prior behavior: load_metadata now
+    # defaults to strict=True (raise on schema-invalid metadata), but the
+    # electrode-table correction does not depend on full schema validity, so
+    # don't newly hard-fail callers here.
     metadata, probe_metadata = convert_yaml.load_metadata(
-        metadata_path, probe_metadata_paths
+        metadata_path, probe_metadata_paths, strict=False
     )
 
     rec_header = convert_rec_header.read_header(trodesconf_path)


### PR DESCRIPTION
Fixes #173.

Previously, a conversion could silently "succeed" on bad input/output:
- `load_metadata` logged schema-validation errors via `logger.exception` and
  continued;
- `_inspect_nwb` only **printed** NWB Inspector CRITICAL/ERROR issues (which
  block DANDI upload), then returned.

## Change
Add `strict: bool = True` to `create_nwbs`, threaded to `_create_nwb`,
`load_metadata`, and `_inspect_nwb`:

- **Metadata**: schema-invalid metadata now raises `ValueError` (strict) instead
  of only logging.
- **NWB Inspector**: any `CRITICAL`/`ERROR`/pynwb-validation issue raises
  `ValueError` (strict) **after** the report file is written; best-practice
  violations and suggestions are still reported but never block.
- **Escape hatch**: `strict=False` restores the previous proceed-and-log
  behavior (useful for debugging / partial data).

Per maintainer decision, the default is `strict=True` with a `strict=False`
opt-out rather than a hard change.

Also fixes a real bug in `metadata_validation`:
`date_of_birth.utcnow().isoformat()` — `utcnow()` is a classmethod that ignores
the instance and returns *now*, so it validated today's date instead of the
subject's DOB. Changed to `date_of_birth.isoformat()`.

Two follow-up hardening fixes from review:
- `validate()` now uses `.get()` for `subject` / `date_of_birth`, so metadata
  missing those keys is reported as a normal schema-validation error instead of
  raising a bare `KeyError` (which under `strict=True` would have bypassed the
  schema report, and under `strict=False` would have crashed instead of
  log-and-continue).
- The NWB Inspector console summary now includes `PYNWB_VALIDATION` so it agrees
  with the DANDI-blocking gate — a pynwb-validation-only failure no longer prints
  "0 critical errors" immediately before the gate raises.

## Tests
- `test_load_metadata_strict_raises_on_invalid` — invalid metadata raises.
- `test_validate_does_not_raise_when_subject_missing` /
  `test_validate_does_not_raise_when_date_of_birth_missing` — `validate()`
  reports missing-key metadata through `(is_valid, errors)` instead of raising.
- `test_convert_full_with_inspector_error` updated: with the default strict=True,
  removing the Subject (→ `CRITICAL: check_subject_exists`) now raises and the
  report is still written; `strict=False` writes the file anyway.
- The clean-sample `test_convert_full` / `test_convert_full_partial_iterators`
  still pass under strict=True (the sample produces no CRITICAL/ERROR).

## Known limitations (deferred)

**Parallel mode (`n_workers > 1`) does not yet enforce `strict`.** The parallel
path catches each session's exception and only prints it, so a strict failure
would not propagate. This is currently *unreachable* in real use: the worker
function is a local closure that recent `distributed` refuses to serialize
("cannot be deterministically hashed", #141), so `n_workers > 1` fails at task
submission before any session runs. #191 fixes both the serialization and the
per-session error handling (failures are aggregated and re-raised as a
`RuntimeError`). The `strict` flag will be threaded through #191's
`_convert_session` on rebase, and `test_convert_full_with_inspector_error` will
then expect the aggregated `RuntimeError` instead of `ValueError`. Serial mode
(the default, `n_workers = 1`) enforces `strict` correctly today.

**Schema `required` under-specification (related #173 item).** `nwb_schema.json`
requires only six top-level fields, so `validate()` returns valid for metadata
missing fields the conversion later dereferences (e.g. `subject`,
`session_description`, `session_id`, `experiment_description`,
`associated_files`). With `strict=True` these are not caught at validation time —
but they are **not** silent successes: conversion fails loudly with a `KeyError`
(e.g. `convert_yaml.add_subject` / `initialize_nwb`). Tightening the schema's
`required` list is the proper fix but is left to its own PR, since expanding it
could reject metadata files that are currently accepted in the wild and warrants
review against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
