### PR TITLE
Output safety: create output_dir up front + refuse silent overwrite (#174)

### DIFF
--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -6,6 +6,7 @@ and final NWB file writing and validation.
 """
 
 import logging
+import tempfile
 from pathlib import Path
 
 import nwbinspector
@@ -229,9 +230,17 @@ def create_nwbs(
         Flag to indicate only behaviorsl data (no ephys) was collected in the rec
         files, by default False.
     overwrite : bool, optional
-        If False (default), refuse to overwrite an existing output ``.nwb`` file
-        and raise ``FileExistsError`` (checked up front, before conversion). If
-        True, replace any existing output file.
+        If False (default), an existing output ``.nwb`` file is not silently
+        overwritten: the conflicting session raises ``FileExistsError`` before
+        any of its conversion work runs. If True, replace any existing output
+        file.
+
+    Raises
+    ------
+    PermissionError
+        If ``output_dir`` exists but is not writable. This is checked once up
+        front (before any conversion) with a create/delete probe, because
+        ``mkdir(exist_ok=True)`` succeeds on an existing read-only directory.
 
     """
 
@@ -247,11 +256,18 @@ def create_nwbs(
     if query_expression is not None:
         file_info = file_info.query(query_expression)
 
-    # Create/validate the output directory up front so a missing or non-writable
-    # path fails immediately instead of after a full (possibly hours-long)
-    # conversion.
+    # Create the output directory up front and confirm it is writable, so a
+    # missing or non-writable path fails immediately instead of after a full
+    # (possibly hours-long) conversion. mkdir(exist_ok=True) alone is not
+    # enough: it succeeds on an existing read-only directory, so probe with a
+    # real create/delete.
     output_dir = str(output_dir)
     Path(output_dir).mkdir(parents=True, exist_ok=True)
+    try:
+        with tempfile.NamedTemporaryFile(dir=output_dir, prefix=".write_probe_"):
+            pass
+    except OSError as e:
+        raise PermissionError(f"Output directory is not writable: {output_dir}") from e
 
     if n_workers > 1:
 

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -196,6 +196,7 @@ def create_nwbs(
     query_expression: str | None = None,
     disable_ptp: bool = False,
     behavior_only: bool = False,
+    overwrite: bool = False,
 ):
     """
     Convert SpikeGadgets data to NWB format.
@@ -227,6 +228,10 @@ def create_nwbs(
     behavior_only : bool, optional
         Flag to indicate only behaviorsl data (no ephys) was collected in the rec
         files, by default False.
+    overwrite : bool, optional
+        If False (default), refuse to overwrite an existing output ``.nwb`` file
+        and raise ``FileExistsError`` (checked up front, before conversion). If
+        True, replace any existing output file.
 
     """
 
@@ -241,6 +246,12 @@ def create_nwbs(
 
     if query_expression is not None:
         file_info = file_info.query(query_expression)
+
+    # Create/validate the output directory up front so a missing or non-writable
+    # path fails immediately instead of after a full (possibly hours-long)
+    # conversion.
+    output_dir = str(output_dir)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     if n_workers > 1:
 
@@ -258,6 +269,7 @@ def create_nwbs(
                     fs_gui_dir,
                     disable_ptp,
                     behavior_only=behavior_only,
+                    overwrite=overwrite,
                 )
                 return True
             except Exception as e:
@@ -288,6 +300,7 @@ def create_nwbs(
                 fs_gui_dir,
                 disable_ptp,
                 behavior_only=behavior_only,
+                overwrite=overwrite,
             )
 
 
@@ -302,11 +315,20 @@ def _create_nwb(
     fs_gui_dir: str = "",
     disable_ptp: bool = False,
     behavior_only: bool = False,
+    overwrite: bool = False,
 ):
     # create loggers
     logger = setup_logger("convert", f"{session[1]}{session[0]}_convert.log")
 
     logger.info(f"Creating NWB file for session: {session}")
+    # Resolve the output path up front and fail fast if it already exists, so a
+    # whole conversion isn't run only to refuse to write at the very end.
+    output_path = Path(f"{output_dir}/{session[1]}{session[0]}.nwb")
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(
+            f"Output file already exists: {output_path}. Pass overwrite=True to "
+            "create_nwbs to replace it."
+        )
     rec_filepaths = _get_file_paths(session_df, ".rec")
     logger.info(f"\trec_filepaths: {rec_filepaths}")
     check_file_timing(rec_filepaths, logger)
@@ -423,8 +445,7 @@ def _create_nwb(
             .data,
         )
 
-    # write file
-    output_path = Path(f"{output_dir}/{session[1]}{session[0]}.nwb")
+    # write file (output_path was resolved and existence-checked up front)
     logger.info(f"WRITING: {output_path}")
     with NWBHDF5IO(output_path, "w") as io:
         io.write(nwb_file)

--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -230,10 +230,10 @@ def create_nwbs(
         Flag to indicate only behaviorsl data (no ephys) was collected in the rec
         files, by default False.
     overwrite : bool, optional
-        If False (default), an existing output ``.nwb`` file is not silently
-        overwritten: the conflicting session raises ``FileExistsError`` before
-        any of its conversion work runs. If True, replace any existing output
-        file.
+        If False (default), an existing output ``.nwb`` file is not
+        overwritten: ``create_nwbs`` raises ``FileExistsError`` (checked before
+        that session's conversion work runs, in both serial and parallel
+        modes). If True, replace any existing output file.
 
     Raises
     ------
@@ -241,6 +241,10 @@ def create_nwbs(
         If ``output_dir`` exists but is not writable. This is checked once up
         front (before any conversion) with a create/delete probe, because
         ``mkdir(exist_ok=True)`` succeeds on an existing read-only directory.
+    FileExistsError
+        If an output ``.nwb`` file already exists and ``overwrite`` is False.
+        In parallel mode (``n_workers > 1``) the other sessions still run; the
+        first failure is re-raised after they finish.
 
     """
 
@@ -297,11 +301,19 @@ def create_nwbs(
         # run conversion for each animal and date
         argument_list = list(file_info.groupby(["date", "animal"]))
         futures = client.map(pass_func, argument_list)
-        # print out error results
+        # collect per-session results; a session that errored (e.g. refused an
+        # existing output) returns its exception instead of True
+        failures = []
         for args, future in zip(argument_list, futures, strict=True):
             result = future.result()
             if result is not True:
                 print(args, result)
+                failures.append(result)
+        # do not report success when a session failed: re-raise so the caller
+        # (and CI) sees the failure, matching the serial path which propagates
+        # it. Aggregated reporting across all failed sessions is added in #141.
+        if failures:
+            raise failures[0]
 
     else:
         for session, session_df in file_info.groupby(["date", "animal"]):

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -69,6 +69,7 @@ def test_convert_full():
         n_workers=1,
         query_expression=f"animal == 'sample' and full_path != '{exclude_reconfig_yaml}'",
         fs_gui_dir=data_path,
+        overwrite=True,
     )
 
     output_file_path = data_path / "sample20230622.nwb"
@@ -116,6 +117,7 @@ def test_convert_full_with_inspector_error(mocker):
         fs_gui_dir=data_path,
         n_workers=1,
         query_expression=f"animal == 'sample' and full_path != '{exclude_reconfig_yaml}'",
+        overwrite=True,
     )
 
     output_file_path = data_path / "sample20230622.nwb"

--- a/src/trodes_to_nwb/tests/test_output_safety.py
+++ b/src/trodes_to_nwb/tests/test_output_safety.py
@@ -1,0 +1,36 @@
+"""Output-safety tests for create_nwbs / _create_nwb (#174)."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from trodes_to_nwb.convert import _create_nwb, create_nwbs
+
+
+def test_create_nwb_refuses_to_overwrite_existing_output(tmp_path):
+    # session is (date, animal); output file is f"{animal}{date}.nwb"
+    session = ("20230101", "rat")
+    (tmp_path / "rat20230101.nwb").write_text("")
+    try:
+        with pytest.raises(FileExistsError, match="already exists"):
+            _create_nwb(
+                session,
+                pd.DataFrame(),
+                output_dir=str(tmp_path),
+                overwrite=False,
+            )
+    finally:
+        # _create_nwb opens a per-session logfile in the CWD before the check
+        logfile = Path("rat20230101_convert.log")
+        if logfile.exists():
+            logfile.unlink()
+
+
+def test_create_nwbs_creates_missing_output_dir(tmp_path):
+    out = tmp_path / "new" / "nested"
+    assert not out.exists()
+    # empty source dir -> no sessions to convert, but the output dir is still
+    # created up front so a bad path fails before any conversion work.
+    create_nwbs(path=tmp_path, output_dir=str(out))
+    assert out.is_dir()

--- a/src/trodes_to_nwb/tests/test_output_safety.py
+++ b/src/trodes_to_nwb/tests/test_output_safety.py
@@ -7,7 +7,40 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from trodes_to_nwb import convert
 from trodes_to_nwb.convert import _create_nwb, create_nwbs
+
+
+class _SyncFuture:
+    """Stand-in for a dask Future that resolves to a value synchronously."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+
+class _SyncClient:
+    """Synchronous stand-in for ``dask.distributed.Client``.
+
+    Runs each mapped task in-process so the parallel branch of ``create_nwbs``
+    can be exercised without spinning up a real cluster (matching how the
+    parallel-mode swallow was originally reproduced with a mock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def map(self, func, iterable):
+        return [_SyncFuture(func(item)) for item in iterable]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
 
 # Permission bits are advisory for the superuser, so a read-only directory is
 # still writable when the suite runs as root (common in CI containers).
@@ -56,3 +89,26 @@ def test_create_nwbs_refuses_non_writable_output_dir(tmp_path):
             create_nwbs(path=tmp_path, output_dir=str(out))
     finally:
         os.chmod(out, stat.S_IRWXU)
+
+
+def test_create_nwbs_parallel_propagates_overwrite_refusal(tmp_path, monkeypatch):
+    # n_workers > 1 must not report success when a session refuses to overwrite:
+    # the worker-side FileExistsError has to propagate to the caller, not just be
+    # printed (the failure mode flagged on #183).
+    date, animal = "20230101", "rat"
+    (tmp_path / f"{animal}{date}.nwb").write_text("")
+    file_info = pd.DataFrame({"date": [date], "animal": [animal]})
+    monkeypatch.setattr(convert, "get_file_info", lambda path: file_info)
+    monkeypatch.setattr(convert, "Client", _SyncClient)
+    try:
+        with pytest.raises(FileExistsError, match="already exists"):
+            create_nwbs(
+                path=tmp_path,
+                output_dir=str(tmp_path),
+                n_workers=2,
+                overwrite=False,
+            )
+    finally:
+        logfile = Path(f"{animal}{date}_convert.log")
+        if logfile.exists():
+            logfile.unlink()

--- a/src/trodes_to_nwb/tests/test_output_safety.py
+++ b/src/trodes_to_nwb/tests/test_output_safety.py
@@ -1,11 +1,17 @@
 """Output-safety tests for create_nwbs / _create_nwb (#174)."""
 
+import os
+import stat
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from trodes_to_nwb.convert import _create_nwb, create_nwbs
+
+# Permission bits are advisory for the superuser, so a read-only directory is
+# still writable when the suite runs as root (common in CI containers).
+_is_root = getattr(os, "geteuid", lambda: 1)() == 0
 
 
 def test_create_nwb_refuses_to_overwrite_existing_output(tmp_path):
@@ -34,3 +40,19 @@ def test_create_nwbs_creates_missing_output_dir(tmp_path):
     # created up front so a bad path fails before any conversion work.
     create_nwbs(path=tmp_path, output_dir=str(out))
     assert out.is_dir()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+@pytest.mark.skipif(_is_root, reason="root bypasses directory permissions")
+def test_create_nwbs_refuses_non_writable_output_dir(tmp_path):
+    # An existing read-only output_dir passes mkdir(exist_ok=True) but cannot be
+    # written to; the create/delete probe must catch this up front rather than
+    # after a full conversion.
+    out = tmp_path / "readonly"
+    out.mkdir()
+    os.chmod(out, stat.S_IRUSR | stat.S_IXUSR)  # read + execute, no write
+    try:
+        with pytest.raises(PermissionError, match="not writable"):
+            create_nwbs(path=tmp_path, output_dir=str(out))
+    finally:
+        os.chmod(out, stat.S_IRWXU)


### PR DESCRIPTION
Fixes #174.

Three output-path footguns:
- the output directory was only touched at the **final write**, so a typo'd or
  non-writable `output_dir` wasted an entire (possibly hours-long) conversion
  before failing;
- an existing `.nwb` was **silently overwritten** (`NWBHDF5IO(path, "w")`),
  which combined with the `query_expression=None` default can clobber prior
  curated files;
- the default `output_dir="/stelmo/nwb/raw"` is lab-internal.

## Change (per maintainer decision: guard + validate, keep the default path)
- `create_nwbs` now `mkdir(parents=True, exist_ok=True)`s `output_dir` **up
  front**, before iterating sessions, so a bad/non-writable path fails fast.
- **Writability probe.** `mkdir(exist_ok=True)` succeeds on an existing
  *read-only* directory, so it alone does not catch a non-writable
  `output_dir` — the failure would still surface only at the final
  `NWBHDF5IO` write. After `mkdir`, `create_nwbs` now does a real
  create/delete probe (`tempfile.NamedTemporaryFile` in `output_dir`) and
  raises `PermissionError` immediately. This is a batch-wide precondition
  (one writable dir is needed for every session), so it is checked once up
  front rather than per session.
- New `overwrite: bool = False`. `_create_nwb` resolves the output path at the
  **top** and raises `FileExistsError` if it exists and `overwrite` is False —
  the refusal happens before that session's conversion work, not after.
  `overwrite=True` replaces the file.
- **Parallel mode no longer reports false success.** With `n_workers > 1` the
  worker caught a session's `FileExistsError`, printed it, and returned it; the
  result loop only printed it again, so `create_nwbs` returned normally and the
  caller/CI saw success despite a refused output. It now collects per-session
  failures and **re-raises the first one** after the batch, matching the serial
  path and keeping the `FileExistsError` contract true in both modes.
  Successful sessions still run (parallel does not abort early).
- The `/stelmo/nwb/raw` default is kept (not removed) per the chosen option.

## Tests
`test_output_safety.py`:
- an existing output is refused with `FileExistsError` (fast, before conversion);
- a missing `output_dir` is created up front;
- an existing **read-only** `output_dir` is refused with `PermissionError` up
  front (skipped on Windows and when running as root, where permission bits
  are advisory);
- **parallel mode** (`n_workers > 1`, via a synchronous fake `Client`)
  propagates the overwrite refusal to the caller instead of swallowing it.

Existing `test_convert.py` full-conversion tests still pass (they now pass
`overwrite=True`, since the bulk test data ships a pre-existing output).

## Coordination with #141 / #191
This PR re-raises the **first** failed session so parallel mode can't report
false success. Full per-session **aggregation** — running every session, then
raising a single summary listing *all* failures — is the root fix in #141/#191
(`_convert_session` + hoisted, picklable worker). #191 also fixes the separate
`n_workers > 1` serialization error (the closure-hashing bug), so real parallel
runs only work end-to-end once #191 lands; this PR's fake-`Client` test
exercises the re-raise logic independently.

Both PRs rewrite the same `create_nwbs` dispatch block and will conflict.
Recommended order: **merge #191 first, then rebase this PR onto it** — the
integration is then just adding `overwrite` to #191's `session_kwargs` plus
this writability probe (the re-raise is subsumed by #191's aggregation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)