### PR TITLE
Code cleanup: logger handler leak, debug prints, dead code (#176)

### DIFF
--- a/src/trodes_to_nwb/convert.py
+++ b/src/trodes_to_nwb/convert.py
@@ -62,6 +62,12 @@ def setup_logger(name_logfile: str, path_logfile: str) -> logging.Logger:
         Logger object
     """
     logger = logging.getLogger(name_logfile)
+    # This is called once per session with the same logger name, so remove any
+    # handlers left over from a previous session; otherwise handlers accumulate
+    # and each session logs duplicate lines and leaks open file handles.
+    for handler in logger.handlers[:]:
+        handler.close()
+        logger.removeHandler(handler)
     formatter = logging.Formatter(
         "%(asctime)s %(message)s", datefmt="%d-%b-%y %H:%M:%S"
     )
@@ -330,13 +336,13 @@ def _create_nwb(
 
     metadata_filepaths = _get_file_paths(session_df, ".yml")
     if len(metadata_filepaths) != 1:
-        try:
-            raise ValueError("There must be exactly one metadata file per session")
-        except ValueError as e:
-            logger.exception("ERROR:")
-            raise e
-    else:
-        metadata_filepaths = metadata_filepaths[0]
+        message = (
+            "There must be exactly one metadata file per session, found "
+            f"{len(metadata_filepaths)}: {metadata_filepaths}"
+        )
+        logger.error(message)
+        raise ValueError(message)
+    metadata_filepaths = metadata_filepaths[0]
     logger.info(f"\tmetadata_filepath: {metadata_filepaths}")
 
     metadata, device_metadata = load_metadata(

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -512,63 +512,6 @@ def correct_timestamps_for_camera_to_mcu_lag(
     return corrected_camera_systime
 
 
-def find_camera_dio_channel(nwb_file: NWBFile) -> np.ndarray:
-    """Finds the timestamp data for the camera DIO channel within an NWB file's
-    behavioral events. Assumes a single channel name contains "camera ticks".
-
-    Parameters
-    ----------
-    nwb_file : NWBFile
-        The NWBFile object to search within.
-
-    Returns
-    -------
-    np.ndarray, shape (n_camera_ticks,)
-        The timestamps (in seconds) of the camera DIO channel.
-
-    Raises
-    ------
-    ValueError
-        If zero or multiple DIO channels containing "camera ticks" are found,
-        or if the necessary processing modules/interfaces are missing.
-    KeyError
-        If 'behavior' processing module or 'behavioral_events' interface is missing.
-    """
-    try:
-        behavior_module = nwb_file.processing["behavior"]
-        behavior_module.data_interfaces["behavioral_events"]
-    except KeyError as e:
-        raise KeyError(
-            f"Missing required NWB structure: {e}. Ensure 'behavior' module and 'behavioral_events' interface exist."
-        ) from e
-
-    dio_camera_name = [
-        key
-        for key in nwb_file.processing["behavior"]
-        .data_interfaces["behavioral_events"]
-        .time_series
-        if "camera ticks" in key
-    ]
-    if len(dio_camera_name) > 1:
-        raise ValueError(
-            f"Multiple camera DIO channels found by name ('camera ticks'): {dio_camera_name}. "
-            "Processing supports only one such channel for non-PTP alignment."
-        )
-
-    if len(dio_camera_name) == 0:
-        raise ValueError(
-            "No camera DIO channel found by name containing 'camera ticks'. "
-            "Check channel names in NWB file or metadata YAML. Required for non-PTP alignment."
-        )
-
-    return (
-        nwb_file.processing["behavior"]
-        .data_interfaces["behavioral_events"]
-        .time_series[dio_camera_name[0]]
-        .timestamps
-    )
-
-
 def get_video_timestamps(video_timestamps_filepath: Path) -> np.ndarray:
     """Reads hardware timestamps from a .cameraHWSync file and returns them in seconds.
 

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -736,9 +736,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
         ValueError
             If any specified `channel_names` are not found in the file.
         """
-        logging.getLogger("convert").debug(
-            "compute multiplex cache %s", self.filename
-        )
+        logging.getLogger("convert").debug("compute multiplex cache %s", self.filename)
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())
@@ -822,9 +820,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
         ValueError
             _description_
         """
-        logging.getLogger("convert").debug(
-            "compute multiplex cache %s", self.filename
-        )
+        logging.getLogger("convert").debug("compute multiplex cache %s", self.filename)
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())
@@ -1272,9 +1268,7 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         Overide of the superclass to use the last state of the previous file segment
         to define the first state of the current file segment.
         """
-        logging.getLogger("convert").debug(
-            "compute multiplex cache %s", self.filename
-        )
+        logging.getLogger("convert").debug("compute multiplex cache %s", self.filename)
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -9,6 +9,7 @@ Intended as a temporary solution until official support is available in Neo.
 # see https://github.com/NeuralEnsemble/python-neo/pull/1303
 
 import functools
+import logging
 from xml.etree import ElementTree
 
 import numpy as np
@@ -735,7 +736,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
         ValueError
             If any specified `channel_names` are not found in the file.
         """
-        print("compute multiplex cache", self.filename)
+        logging.getLogger("convert").debug(
+            "compute multiplex cache %s", self.filename
+        )
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())
@@ -819,7 +822,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
         ValueError
             _description_
         """
-        print("compute multiplex cache", self.filename)
+        logging.getLogger("convert").debug(
+            "compute multiplex cache %s", self.filename
+        )
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())
@@ -1051,7 +1056,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
         self,
     ):
         # """Interpolates single dropped packets in the analog data."""
-        print("Interpolate memmap: ", self.filename)
+        logging.getLogger("convert").debug("Interpolate memmap: %s", self.filename)
         self._raw_memmap = InsertedMemmap(self._raw_memmap, self.interpolate_index)
 
     def get_stream_index_from_id(self, stream_id: int) -> int:
@@ -1267,7 +1272,9 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         Overide of the superclass to use the last state of the previous file segment
         to define the first state of the current file segment.
         """
-        print("compute multiplex cache", self.filename)
+        logging.getLogger("convert").debug(
+            "compute multiplex cache %s", self.filename
+        )
         if channel_names is None:
             # read all multiplexed channels
             channel_names = list(self.multiplexed_channel_xml.keys())

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -54,6 +54,24 @@ def test_get_included_device_metadata_paths():
     assert all(probe.exists() for probe in probes)
 
 
+def test_setup_logger_does_not_accumulate_handlers(tmp_path):
+    # setup_logger is called once per session with the same logger name; it must
+    # clear prior handlers so repeated calls don't duplicate log lines or leak
+    # open file handles.
+    import logging
+
+    name = "test_setup_logger_no_accumulation"
+    logfile = str(tmp_path / "convert.log")
+    logger = setup_logger(name, logfile)
+    n_handlers = len(logger.handlers)
+    assert n_handlers == 2  # one FileHandler + one StreamHandler
+
+    for _ in range(3):
+        again = setup_logger(name, logfile)
+    assert again is logger  # same named logger object
+    assert len(again.handlers) == n_handlers  # not accumulated across calls
+
+
 def test_convert_full():
     device_metadata = get_included_device_metadata_paths()
 


### PR DESCRIPTION
Part of #176 — completes the debug-`print`s, logger-handler-leak, dead-code (`find_camera_dio_channel`), and `raise`/`except` items. **Remaining in #176** (keep open): production code importing the test package (`convert_optogenetics`), and writing logfiles into `output_dir` rather than the CWD.

---

Fixes part of #176 (low-risk cleanup; two items deferred — see below).

No behavior change:
- **Logger handler leak** — `setup_logger` is called once per session with the
  same logger name but never cleared its handlers, so session 2 logged every
  line twice, session 3 three times, and old file handles leaked. Now closes and
  removes prior handlers first.
- **Debug prints in production** — four stray `print()`s in
  `spike_gadgets_raw_io.py` (`"compute multiplex cache"` ×3, `"Interpolate
  memmap"`) spammed stdout on every conversion; converted to
  `logging.getLogger("convert").debug(...)`.
- **Dead code** — removed `find_camera_dio_channel` (unused; the live path is
  `find_camera_dio_channel_per_epoch`).
- **`raise`/`except`/`reraise` anti-pattern** — the metadata-file-count check in
  `_create_nwb` raised only to immediately catch, log, and re-raise; replaced
  with `logger.error(...)` + `raise ValueError(...)` (now reports the count).

## Deferred to follow-ups (not in this PR)
- The production→tests import (`convert_optogenetics` importing
  `trodes_to_nwb.tests.utils.data_path`) is entangled with how opto geometry
  files are resolved; untangling it safely warrants its own change.
- The vestigial `map_number` in `validate_yaml_header_electrode_map` — that
  validator is under separate discussion in #107.

## Tests
`test_convert.py`, `test_convert_position.py`, `test_spikegadgets_io.py` all pass
(34 passed, 16 slow/integration skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)