### PR TITLE
Catch metadata cross-reference errors early (#147)

### DIFF
--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -59,6 +59,19 @@ def load_metadata(
     if not is_metadata_valid:
         logger = logging.getLogger("convert")
         logger.exception("".join(metadata_errors))
+    else:
+        # Schema is valid; check the cross-references the schema cannot express
+        # (issue #147) so a broken reference fails here -- early, before any
+        # conversion work and regardless of behavior_only -- with a clear message
+        # rather than crashing deep in conversion (e.g. an unmapped electrode
+        # group later hits a NoneType error).
+        reference_errors = (
+            trodes_to_nwb.metadata_validation.validate_metadata_references(metadata)
+        )
+        if reference_errors:
+            raise ValueError(
+                "Metadata reference error(s):\n  - " + "\n  - ".join(reference_errors)
+            )
     device_metadata = []
     for path in device_metadata_paths:
         with open(path) as stream:

--- a/src/trodes_to_nwb/metadata_validation.py
+++ b/src/trodes_to_nwb/metadata_validation.py
@@ -75,3 +75,132 @@ def validate(metadata: dict) -> tuple:
     is_valid = len(errors) == 0
 
     return is_valid, errors
+
+
+def _duplicates(values: list) -> list:
+    """Return the values that appear more than once, in first-seen order."""
+    seen: set = set()
+    duplicated: list = []
+    for value in values:
+        if value in seen and value not in duplicated:
+            duplicated.append(value)
+        seen.add(value)
+    return duplicated
+
+
+def _dict_items(value) -> list[dict]:
+    """Return only the ``dict`` elements of a value expected to be a list of dicts.
+
+    Tolerates ``None``, a non-list, or a list with non-dict entries so the
+    reference checks degrade to a clean message rather than crashing on
+    malformed metadata.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _as_list(value) -> list:
+    """Coerce ``None``/a scalar to a list so a mistakenly-scalar field is iterated."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _sort_key(value):
+    """Sort key that tolerates mixed/None reference values for error messages."""
+    return (value is None, str(value))
+
+
+def validate_metadata_references(metadata: dict) -> list[str]:
+    """Check cross-references *within* the metadata that the JSON schema cannot
+    express, so broken references surface as clear errors up front instead of as
+    cryptic failures deep in conversion (issue #147).
+
+    Checks performed:
+
+    - electrode group ids are unique;
+    - every electrode group has at least one
+      ``ntrode_electrode_group_channel_map`` entry (an unmapped group otherwise
+      crashes ``add_electrode_groups`` with a ``NoneType`` error), and every
+      ntrode map entry references an electrode group that exists;
+    - ``ntrode_id`` values are unique;
+    - camera ids are unique, and every ``camera_id`` referenced by ``tasks`` or
+      ``associated_video_files`` is defined in ``cameras``.
+
+    The function is defensive: it returns a list of messages and never raises,
+    even on malformed/partial metadata (a non-dict list element, a scalar
+    ``camera_id``, a missing key), so it degrades to clear text rather than a
+    stack trace. ``device_type``-vs-probe coverage is intentionally not checked
+    here -- probes are only required at ``add_electrode_groups``, which validates
+    that itself.
+
+    Parameters
+    ----------
+    metadata : dict
+        Parsed session metadata.
+
+    Returns
+    -------
+    list[str]
+        Human-readable error messages; empty if every reference is consistent.
+    """
+    errors: list[str] = []
+
+    electrode_groups = _dict_items(metadata.get("electrode_groups"))
+    electrode_group_ids = [group.get("id") for group in electrode_groups]
+    duplicate_group_ids = _duplicates(electrode_group_ids)
+    if duplicate_group_ids:
+        errors.append(f"Duplicate electrode_groups id(s): {duplicate_group_ids}.")
+    electrode_group_id_set = set(electrode_group_ids)
+
+    ntrode_map = _dict_items(metadata.get("ntrode_electrode_group_channel_map"))
+    mapped_group_ids = [entry.get("electrode_group_id") for entry in ntrode_map]
+    dangling = sorted(
+        {gid for gid in mapped_group_ids if gid not in electrode_group_id_set},
+        key=_sort_key,
+    )
+    if dangling:
+        errors.append(
+            "ntrode_electrode_group_channel_map references electrode_group_id(s) "
+            f"{dangling} not defined in electrode_groups."
+        )
+    unmapped = sorted(electrode_group_id_set - set(mapped_group_ids), key=_sort_key)
+    if unmapped:
+        errors.append(
+            f"electrode_groups id(s) {unmapped} have no entry in "
+            "ntrode_electrode_group_channel_map (each electrode group needs one)."
+        )
+    duplicate_ntrode_ids = _duplicates([entry.get("ntrode_id") for entry in ntrode_map])
+    if duplicate_ntrode_ids:
+        errors.append(
+            "Duplicate ntrode_id(s) in ntrode_electrode_group_channel_map: "
+            f"{duplicate_ntrode_ids}."
+        )
+
+    cameras = _dict_items(metadata.get("cameras"))
+    camera_ids = [camera.get("id") for camera in cameras]
+    duplicate_camera_ids = _duplicates(camera_ids)
+    if duplicate_camera_ids:
+        errors.append(f"Duplicate camera id(s): {duplicate_camera_ids}.")
+    camera_id_set = set(camera_ids)
+    for task in _dict_items(metadata.get("tasks")):
+        # camera_id should be a list, but tolerate a scalar (a common mistake)
+        # so a bad reference is still reported rather than silently skipped.
+        for camera_id in _as_list(task.get("camera_id")):
+            if camera_id not in camera_id_set:
+                errors.append(
+                    f"task '{task.get('task_name')}' references camera_id "
+                    f"{camera_id} not defined in cameras."
+                )
+    for video in _dict_items(metadata.get("associated_video_files")):
+        camera_id = video.get("camera_id")
+        if camera_id is not None and camera_id not in camera_id_set:
+            errors.append(
+                f"associated_video_files entry '{video.get('name')}' references "
+                f"camera_id {camera_id} not defined in cameras."
+            )
+
+    return errors

--- a/src/trodes_to_nwb/metadata_validation.py
+++ b/src/trodes_to_nwb/metadata_validation.py
@@ -130,17 +130,24 @@ def validate_metadata_references(metadata: dict) -> list[str]:
     - camera ids are unique, and every ``camera_id`` referenced by ``tasks`` or
       ``associated_video_files`` is defined in ``cameras``.
 
-    The function is defensive: it returns a list of messages and never raises,
-    even on malformed/partial metadata (a non-dict list element, a scalar
-    ``camera_id``, a missing key), so it degrades to clear text rather than a
-    stack trace. ``device_type``-vs-probe coverage is intentionally not checked
-    here -- probes are only required at ``add_electrode_groups``, which validates
-    that itself.
+    Intended to run *after* JSON-schema validation (see ``load_metadata``),
+    which already guarantees ``metadata`` is a dict with correctly-typed fields.
+    The caller raises on any returned message, so a broken reference fails fast
+    -- before the long conversion -- rather than crashing cryptically partway
+    through. Broken references are returned as messages (not raised here) so the
+    caller can report them all at once. Absent or partial sections (a missing
+    key, a ``None`` section, a non-dict list element, or a scalar ``camera_id``
+    where a list is expected) are treated as "nothing to cross-check" rather
+    than crashing; field *types* themselves are the schema's responsibility, not
+    re-validated here, so this is not a substitute for schema validation.
+    ``device_type``-vs-probe coverage is intentionally not checked here --
+    probes are only required at ``add_electrode_groups``, which validates that
+    itself.
 
     Parameters
     ----------
     metadata : dict
-        Parsed session metadata.
+        Parsed, schema-valid session metadata.
 
     Returns
     -------

--- a/src/trodes_to_nwb/metadata_validation.py
+++ b/src/trodes_to_nwb/metadata_validation.py
@@ -127,8 +127,8 @@ def validate_metadata_references(metadata: dict) -> list[str]:
       crashes ``add_electrode_groups`` with a ``NoneType`` error), and every
       ntrode map entry references an electrode group that exists;
     - ``ntrode_id`` values are unique;
-    - camera ids are unique, and every ``camera_id`` referenced by ``tasks`` or
-      ``associated_video_files`` is defined in ``cameras``.
+    - camera ids are unique, and every ``camera_id`` referenced by ``tasks``,
+      ``associated_video_files``, or ``fs_gui_yamls`` is defined in ``cameras``.
 
     Intended to run *after* JSON-schema validation (see ``load_metadata``),
     which already guarantees ``metadata`` is a dict with correctly-typed fields.
@@ -207,6 +207,16 @@ def validate_metadata_references(metadata: dict) -> list[str]:
         if camera_id is not None and camera_id not in camera_id_set:
             errors.append(
                 f"associated_video_files entry '{video.get('name')}' references "
+                f"camera_id {camera_id} not defined in cameras."
+            )
+    for fs_gui in _dict_items(metadata.get("fs_gui_yamls")):
+        # fs_gui camera_id is resolved as a "camera_device {camera_id}" device in
+        # add_optogenetic_epochs; a dangling id otherwise raises only there, late
+        # in conversion. (Scalar integer per schema, like associated_video_files.)
+        camera_id = fs_gui.get("camera_id")
+        if camera_id is not None and camera_id not in camera_id_set:
+            errors.append(
+                f"fs_gui_yamls entry '{fs_gui.get('name')}' references "
                 f"camera_id {camera_id} not defined in cameras."
             )
 

--- a/src/trodes_to_nwb/tests/test_convert_yaml.py
+++ b/src/trodes_to_nwb/tests/test_convert_yaml.py
@@ -3,6 +3,8 @@ import os
 import shutil
 from datetime import datetime
 
+import pytest
+import yaml
 from hdmf.common.table import DynamicTable, VectorData
 from ndx_franklab_novela import CameraDevice, Probe, Shank, ShanksElectrode
 from pynwb.file import ProcessingModule, Subject
@@ -398,3 +400,22 @@ def test_add_associated_video_files():
 
     # cleanup
     shutil.rmtree(video_directory)
+
+
+def test_load_metadata_raises_on_broken_references(tmp_path, mocker):
+    # load_metadata validates cross-references on schema-valid metadata and
+    # raises early -- before any conversion work and regardless of behavior_only
+    # (#147). A schema-valid file with an unmapped electrode group must raise.
+    metadata = {
+        "electrode_groups": [{"id": 0}],
+        "ntrode_electrode_group_channel_map": [],  # electrode group 0 unmapped
+        "associated_files": None,
+        "associated_video_files": None,
+    }
+    metadata_path = tmp_path / "20230101_rat_metadata.yml"
+    metadata_path.write_text(yaml.safe_dump(metadata))
+    # treat the schema as valid so the referential check (the code under test) runs
+    mocker.patch("trodes_to_nwb.metadata_validation.validate", return_value=(True, []))
+
+    with pytest.raises(ValueError, match="Metadata reference error"):
+        convert_yaml.load_metadata(metadata_path, [])

--- a/src/trodes_to_nwb/tests/test_metadata_validation.py
+++ b/src/trodes_to_nwb/tests/test_metadata_validation.py
@@ -2,8 +2,103 @@ import copy
 import datetime
 from unittest.mock import patch
 
-from trodes_to_nwb.metadata_validation import _get_nwb_json_schema_path, validate
+import pytest
+import yaml
+
+from trodes_to_nwb.metadata_validation import (
+    _get_nwb_json_schema_path,
+    validate,
+    validate_metadata_references,
+)
 from trodes_to_nwb.tests.test_data import test_metadata_dict_samples
+from trodes_to_nwb.tests.utils import data_path
+
+
+def _reference_metadata() -> dict:
+    """Minimal, internally-consistent metadata for the reference checks."""
+    return {
+        "electrode_groups": [{"id": 0}, {"id": 1}],
+        "ntrode_electrode_group_channel_map": [
+            {"ntrode_id": 1, "electrode_group_id": 0},
+            {"ntrode_id": 2, "electrode_group_id": 1},
+        ],
+        "cameras": [{"id": 0}, {"id": 1}],
+        "tasks": [{"task_name": "run", "camera_id": [0, 1]}],
+        "associated_video_files": [{"name": "v.h264", "camera_id": 0}],
+    }
+
+
+def test_validate_metadata_references_consistent_is_empty():
+    assert validate_metadata_references(_reference_metadata()) == []
+
+
+def test_validate_metadata_references_unmapped_and_dangling_electrode_groups():
+    metadata = _reference_metadata()
+    # point one ntrode entry at a nonexistent group -> dangling ref AND leaves
+    # electrode group 1 with no map entry (the NoneType-crash case).
+    metadata["ntrode_electrode_group_channel_map"][1]["electrode_group_id"] = 99
+    errors = validate_metadata_references(metadata)
+    assert any("not defined in electrode_groups" in e and "99" in e for e in errors)
+    assert any("no entry in" in e and "[1]" in e for e in errors)
+
+
+def test_validate_metadata_references_bad_camera_id():
+    metadata = _reference_metadata()
+    metadata["tasks"][0]["camera_id"] = [7]
+    metadata["associated_video_files"][0]["camera_id"] = 8
+    errors = validate_metadata_references(metadata)
+    assert any("camera_id 7" in e for e in errors)
+    assert any("camera_id 8" in e for e in errors)
+
+
+def test_validate_metadata_references_duplicate_ids():
+    metadata = _reference_metadata()
+    metadata["electrode_groups"].append({"id": 0})
+    metadata["cameras"].append({"id": 1})
+    metadata["ntrode_electrode_group_channel_map"].append(
+        {"ntrode_id": 1, "electrode_group_id": 0}
+    )
+    errors = validate_metadata_references(metadata)
+    assert any("Duplicate electrode_groups id" in e for e in errors)
+    assert any("Duplicate camera id" in e for e in errors)
+    assert any("Duplicate ntrode_id" in e for e in errors)
+
+
+def test_validate_metadata_references_scalar_camera_id_is_checked():
+    # A scalar camera_id (a common mistake; the schema expects a list) must still
+    # be validated, not silently skipped by a falsy `0 or []`.
+    metadata = _reference_metadata()
+    metadata["tasks"][0]["camera_id"] = 0  # scalar, references existing camera 0
+    assert validate_metadata_references(metadata) == []
+    metadata["tasks"][0]["camera_id"] = 7  # scalar, nonexistent
+    assert any("camera_id 7" in e for e in validate_metadata_references(metadata))
+
+
+def test_validate_metadata_references_tolerates_malformed_metadata():
+    # Must return a list (never raise) even on malformed shapes the schema would
+    # reject -- a clear message, not a stack trace (#147).
+    malformed = {
+        "electrode_groups": ["not-a-dict"],
+        "ntrode_electrode_group_channel_map": "oops",
+        "cameras": [5],
+        "tasks": [{"task_name": "t", "camera_id": 0}],
+        "associated_video_files": None,
+    }
+    result = validate_metadata_references(malformed)
+    assert isinstance(result, list)  # did not raise on non-dict / scalar shapes
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["20230622_sample_metadata.yml", "20230622_sample_metadataProbeReconfig.yml"],
+)
+def test_validate_metadata_references_no_false_positives_on_real_metadata(filename):
+    # The highest-risk property: a single over-eager check would break every real
+    # conversion. The reconfig file legitimately has multiple ntrode entries per
+    # electrode group.
+    with open(data_path / filename) as stream:
+        metadata = yaml.safe_load(stream)
+    assert validate_metadata_references(metadata) == []
 
 
 def test_path_to_json_schema_is_correct():

--- a/src/trodes_to_nwb/tests/test_metadata_validation.py
+++ b/src/trodes_to_nwb/tests/test_metadata_validation.py
@@ -25,6 +25,7 @@ def _reference_metadata() -> dict:
         "cameras": [{"id": 0}, {"id": 1}],
         "tasks": [{"task_name": "run", "camera_id": [0, 1]}],
         "associated_video_files": [{"name": "v.h264", "camera_id": 0}],
+        "fs_gui_yamls": [{"name": "opto.yaml", "camera_id": 1}],
     }
 
 
@@ -49,6 +50,16 @@ def test_validate_metadata_references_bad_camera_id():
     errors = validate_metadata_references(metadata)
     assert any("camera_id 7" in e for e in errors)
     assert any("camera_id 8" in e for e in errors)
+
+
+def test_validate_metadata_references_bad_fs_gui_camera_id():
+    # fs_gui_yamls camera_id is resolved as a camera device in
+    # add_optogenetic_epochs; a dangling id otherwise fails only late in
+    # conversion (#147). The schema requires it but cannot check the reference.
+    metadata = _reference_metadata()
+    metadata["fs_gui_yamls"][0]["camera_id"] = 9  # no such camera
+    errors = validate_metadata_references(metadata)
+    assert any("fs_gui_yamls" in e and "camera_id 9" in e for e in errors)
 
 
 def test_validate_metadata_references_duplicate_ids():

--- a/src/trodes_to_nwb/tests/test_metadata_validation.py
+++ b/src/trodes_to_nwb/tests/test_metadata_validation.py
@@ -74,18 +74,21 @@ def test_validate_metadata_references_scalar_camera_id_is_checked():
     assert any("camera_id 7" in e for e in validate_metadata_references(metadata))
 
 
-def test_validate_metadata_references_tolerates_malformed_metadata():
-    # Must return a list (never raise) even on malformed shapes the schema would
-    # reject -- a clear message, not a stack trace (#147).
-    malformed = {
+def test_validate_metadata_references_tolerates_partial_sections():
+    # Absent/partial sections (a None section, a non-dict list element, a
+    # string-where-list, a scalar camera_id) must degrade to "nothing to
+    # cross-check" rather than crashing -- the checker reports broken references
+    # as messages, it does not re-validate field *types* (the schema does that,
+    # and runs first). So this returns a list, never a stack trace (#147).
+    partial = {
         "electrode_groups": ["not-a-dict"],
         "ntrode_electrode_group_channel_map": "oops",
         "cameras": [5],
         "tasks": [{"task_name": "t", "camera_id": 0}],
         "associated_video_files": None,
     }
-    result = validate_metadata_references(malformed)
-    assert isinstance(result, list)  # did not raise on non-dict / scalar shapes
+    result = validate_metadata_references(partial)
+    assert isinstance(result, list)  # did not raise on partial / non-dict shapes
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Part of #147 (adds the referential checks; the broader pre-flight-validation phase is tracked in the issue, to be done as a coordinating PR after #182 / #183 / #141 land).

## Problem
The JSON schema validates field *types/presence*, but it cannot express *references* between metadata sections. So a broken reference passes schema validation and then fails cryptically deep in conversion — after the expensive ephys work has already started:
- an `electrode_groups` entry with no `ntrode_electrode_group_channel_map` entry → `channel_map` stays `None` → `TypeError: 'NoneType' object is not subscriptable` in `add_electrode_groups`;
- a `camera_id` in `tasks`/`associated_video_files`/`fs_gui_yamls` that no camera defines → silently wrong references downstream (Spyglass), or a late `ValueError` in `add_optogenetic_epochs` for the fs-gui case.

## Change
New `validate_metadata_references(metadata)` in `metadata_validation.py` checks the references the schema can't:
- electrode group ids unique; **every electrode group has ≥1 ntrode map entry** and every ntrode entry references a **defined** electrode group; `ntrode_id`s unique;
- camera ids unique; **every `camera_id`** used by `tasks`, `associated_video_files`, or `fs_gui_yamls` is defined in `cameras`.

It returns the broken references as a list of messages (it does not raise itself), so they can be reported all at once. It runs *after* schema validation and is not a substitute for it — field types remain the schema's job.

**Wired in `load_metadata`:** once schema validation succeeds, the references are checked and **any** broken reference raises a single `ValueError` listing them all. This fails fast — before any conversion work and regardless of `behavior_only` — rather than crashing partway through a long conversion.

## Scope / overlap (checked per request)
- **`device_type`-vs-probe coverage is intentionally _not_ checked here** — probes are only required at `add_electrode_groups`, which already raises its own clear error for a missing `device_type`. (`add_electrode_groups` is therefore unchanged by this PR.)
- **#182** (validation gating) owns *schema* validation in `load_metadata`; this PR adds the referential check alongside that path and does not modify the schema handling.
- **#148** validates against the *spyglass database* (a separate file/concern) — no overlap.

## Tests
- `validate_metadata_references`: consistent metadata → no errors; unmapped/dangling electrode groups; bad `camera_id` (task + video + fs_gui, including a scalar `camera_id`); duplicate ids; tolerates absent/partial sections without crashing.
- No false positives on the real sample and reconfig metadata.
- `load_metadata` raises early (`ValueError`) on a schema-valid file with an unmapped electrode group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
