### PR TITLE
Fix strange associated-files task_epochs join (#10)

### DIFF
--- a/src/trodes_to_nwb/convert_yaml.py
+++ b/src/trodes_to_nwb/convert_yaml.py
@@ -441,8 +441,13 @@ def add_associated_files(nwbfile: NWBFile, metadata: dict) -> None:
         except OSError as err:
             logger.info(f"ERROR: Cannot read file at {file['path']}")
             logger.info(str(err))
-        # convert task epoch values into strings
-        task_epochs = "".join([str(element) + ", " for element in file["task_epochs"]])
+        # Comma-separated 1-based epoch number(s) with no spaces or trailing
+        # comma. Spyglass reads this back via ``task_epochs.split(",")`` and
+        # matches each token against the epoch number, so a leading space (from
+        # ", ") or a trailing comma would break the match -- e.g. "1, 2, " splits
+        # to ["1", " 2", " "] and " 2" != "2" (issue #10; see spyglass
+        # common_behav.py).
+        task_epochs = ",".join(str(element) for element in file["task_epochs"])
         associated_files.append(
             AssociatedFiles(
                 name=file["name"],

--- a/src/trodes_to_nwb/tests/test_convert_yaml.py
+++ b/src/trodes_to_nwb/tests/test_convert_yaml.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from hdmf.common.table import DynamicTable, VectorData
 from ndx_franklab_novela import CameraDevice, Probe, Shank, ShanksElectrode
+from pynwb import NWBFile
 from pynwb.file import ProcessingModule, Subject
 
 from trodes_to_nwb import convert, convert_rec_header, convert_yaml
@@ -334,9 +335,15 @@ def test_add_associated_files(capsys):
         nwbfile.processing["associated_files"]["associated1.txt"].description
         == "good file"
     )
-    assert (
-        nwbfile.processing["associated_files"]["associated1.txt"].task_epochs == "1, "
-    )
+    # Comma-separated with no spaces / trailing comma (issue #10): Spyglass
+    # reads this via task_epochs.split(",") and matches each token.
+    realistic_task_epochs = nwbfile.processing["associated_files"][
+        "associated1.txt"
+    ].task_epochs
+    assert realistic_task_epochs == "1"
+    assert "1" in realistic_task_epochs.split(
+        ","
+    )  # matches Spyglass's membership check
     assert (
         nwbfile.processing["associated_files"]["associated1.txt"].content
         == "test file 1"
@@ -358,6 +365,53 @@ def test_add_associated_files(capsys):
                         printed_warning = True
                     break
     assert printed_warning
+
+
+def test_add_associated_files_task_epochs_format(tmp_path):
+    # Issue #10: task_epochs must be comma-separated with no spaces or trailing
+    # comma, so Spyglass's `task_epochs.split(",")` yields exact epoch tokens.
+    # Build metadata directly with multiple epochs (load_metadata wraps a scalar,
+    # so the multi-epoch path is only reachable here) -- this is the case the old
+    # '", "'.join format broke (" 2" != "2").
+    associated = tmp_path / "assoc.txt"
+    associated.write_text("contents")
+    metadata = {
+        "associated_files": [
+            {
+                "name": "assoc.txt",
+                "description": "statescript",
+                "path": str(associated),
+                "task_epochs": [1, 2, 10],
+            }
+        ]
+    }
+    nwbfile = NWBFile(
+        session_description="d", identifier="i", session_start_time=datetime.now()
+    )
+    convert_yaml.add_associated_files(nwbfile, metadata)
+
+    task_epochs = nwbfile.processing["associated_files"]["assoc.txt"].task_epochs
+    assert task_epochs == "1,2,10"
+    # round-trips through Spyglass's split(",") to exact, space-free tokens
+    assert task_epochs.split(",") == ["1", "2", "10"]
+    assert "2" in task_epochs.split(",")
+
+    # An empty epoch list yields an empty string (pinned behaviour).
+    empty_metadata = {
+        "associated_files": [
+            {
+                "name": "empty.txt",
+                "description": "d",
+                "path": str(associated),
+                "task_epochs": [],
+            }
+        ]
+    }
+    nwbfile_empty = NWBFile(
+        session_description="d", identifier="i2", session_start_time=datetime.now()
+    )
+    convert_yaml.add_associated_files(nwbfile_empty, empty_metadata)
+    assert nwbfile_empty.processing["associated_files"]["empty.txt"].task_epochs == ""
 
 
 def test_add_associated_video_files():


### PR DESCRIPTION
Closes #10.

## The strange line
`add_associated_files` built the `AssociatedFiles.task_epochs` string as:
```python
task_epochs = "".join([str(element) + ", " for element in file["task_epochs"]])
```
which yields a trailing-comma, space-padded string like `"1, 2, "`.

## Why it is wrong (verified against the spyglass consumer)
Spyglass reads this field in exactly one place — `common/common_behav.py` — as
```python
epoch_list = associated_file_obj.task_epochs.split(",")
... and str(key["epoch"]) in epoch_list
```
with **no space-stripping**. So `"1, 2, ".split(",")` → `["1", " 2", " "]`, and `" 2" != "2"` — every epoch after the first fails to match, plus a trailing empty token. It only works today because `load_metadata` wraps an associated file’s `task_epochs` to a *single*-element list, so the one token happens to have no leading space. The format is fragile and wrong for multiple epochs. (Trodes has no `task_epochs`/`AssociatedFiles` concept, so nothing to verify there.)

## Fix
```python
task_epochs = ",".join(str(element) for element in file["task_epochs"])
```
→ `"1,2,10"`: no spaces, no trailing comma, so `split(",")` gives exact, space-free epoch tokens that match `str(epoch)`. Spyglass’s own TODO is to make this an int array eventually; a clean comma-joined int string is the correct interim form.

## Tests
- Updated the existing assertion (`"1, "` → `"1"`).
- Added `test_add_associated_files_task_epochs_format` (multi-epoch `[1, 2, 10]` → `"1,2,10"`, and `split(",")` round-trips to `["1","2","10"]`) — the case the old format broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)