### PR TITLE
DIO: unit N/A + describe by header channel id and input flag (#116, #117)

### DIFF
--- a/src/trodes_to_nwb/convert_dios.py
+++ b/src/trodes_to_nwb/convert_dios.py
@@ -2,14 +2,48 @@
 from Trodes .rec files into NWB TimeSeries within a BehavioralEvents container.
 """
 
+import logging
+
 import numpy as np
 from pynwb import NWBFile, TimeSeries
 from pynwb.behavior import BehavioralEvents
 
+from .convert_rec_header import read_header
 from .spike_gadgets_raw_io import SpikeGadgetsRawIO
 
 
-def _get_channel_name_map(metadata: dict) -> dict[str, str]:
+def _get_digital_channel_input_map(recfile: str) -> dict[str, str | None]:
+    """Map each digital channel's header id to its ``input`` flag.
+
+    Reads the ``.rec`` header and returns ``{channel_id: input}`` for every
+    digital ``<Channel>``, where ``input`` is ``"1"`` for a digital input and
+    ``"0"`` for a digital output. Used to record the specific hardware channel
+    and its direction in each DIO TimeSeries description (issues #116, #117).
+
+    Parameters
+    ----------
+    recfile : str
+        Path to a ``.rec`` file whose header is read.
+
+    Returns
+    -------
+    dict[str, str | None]
+        ``{header channel id -> input flag}`` (e.g. ``{"ECU_Din1": "1"}``); the
+        flag is ``None`` for the rare channel with no ``input`` attribute.
+    """
+    hardware_config = read_header(recfile).find("HardwareConfiguration")
+    channel_input_map = {}
+    if hardware_config is not None:
+        for device in hardware_config:
+            for channel in device:
+                if channel.attrib.get("dataType") == "digital":
+                    channel_input_map[channel.attrib["id"]] = channel.attrib.get(
+                        "input"
+                    )
+    return channel_input_map
+
+
+def _get_channel_name_map(metadata: dict) -> dict[str, dict]:
     """Parses behavioral events metadata from the yaml file.
 
     Parameters
@@ -68,6 +102,10 @@ def add_dios(nwbfile: NWBFile, recfile: list[str], metadata: dict) -> None:
     # to a human-readable name (encoded in `name`)
     channel_name_map = _get_channel_name_map(metadata)
 
+    # Map each digital channel's header id to its input flag, for the per-channel
+    # description (#116 traceability + #117 direction).
+    channel_input_map = _get_digital_channel_input_map(recfile[0])
+
     # Loop through the channels from the metadata YAML and add a TimeSeries for each one
     stream_name = "ECU_digital"
     # Address issue where some Trodes verions have ECU_ prefix and some don't
@@ -94,12 +132,31 @@ def add_dios(nwbfile: NWBFile, recfile: list[str], metadata: dict) -> None:
         state_changes = np.concatenate(state_changes)
         assert isinstance(timestamps[0], np.float64)
         assert isinstance(timestamps, np.ndarray)
+        # Describe the channel by its specific hardware id (#116) and its
+        # direction from the header `input` flag -- 1 = digital input, 0 = digital
+        # output -- giving both the verbatim attribute and a human gloss (#117).
+        full_channel_id = prefix + channel_name
+        input_flag = channel_input_map.get(full_channel_id)
+        if input_flag is None:
+            # The channel resolved for data extraction (get_digitalsignal above
+            # would have raised otherwise) but the header carries no `input`
+            # attribute, so we can't state the direction -- keep the id and warn
+            # rather than silently omitting it.
+            logging.getLogger("convert").warning(
+                "DIO channel %s has no 'input' flag in the header; recording the "
+                "channel id without a direction.",
+                full_channel_id,
+            )
+            description = full_channel_id
+        else:
+            direction = "input" if input_flag == "1" else "output"
+            description = f"{full_channel_id}, input={input_flag} (digital {direction})"
         ts = TimeSeries(
             name=channel_name_map[channel_name]["name"],
             comments=channel_name_map[channel_name]["comments"],
-            description=channel_name,
+            description=description,
             data=state_changes,
-            unit="-1",  # TODO change to "N/A",
+            unit="N/A",
             timestamps=timestamps,  # TODO adjust timestamps
         )
         beh_events.add_timeseries(ts)

--- a/src/trodes_to_nwb/tests/test_convert.py
+++ b/src/trodes_to_nwb/tests/test_convert.py
@@ -253,10 +253,11 @@ def compare_nwbfiles(nwbfile, old_nwbfile, truncated_size=False):
             rtol=0,
             atol=1.0 / 30000,
         )
-        assert (current_dio.unit == old_dio.unit) or (
-            (current_dio.unit == "-1") and (old_dio.unit == "'unspecified'")
-        )  # old rec_to_nwb conversions have a different default for unspecified units
-        assert current_dio.description == old_dio.description
+        # unit is now "N/A" and the description records the header channel id +
+        # input flag (#116, #117), so neither still matches the old rec_to_nwb
+        # reference; the data/timestamp equivalence above is the real check.
+        assert current_dio.unit == "N/A"
+        assert ", input=" in current_dio.description
 
     # Compare position data
     for series in nwbfile.processing["behavior"]["position"].spatial_series:

--- a/src/trodes_to_nwb/tests/test_convert_dios.py
+++ b/src/trodes_to_nwb/tests/test_convert_dios.py
@@ -54,8 +54,11 @@ def test_add_dios_single_rec():
                     rtol=0,
                     atol=1.0 / 30000,
                 )
-                assert current_dio.unit == old_dio.unit
-                assert current_dio.description == old_dio.description
+                # unit is now "N/A" and the description records the header channel
+                # id + input flag (#116, #117), so neither still matches the old
+                # rec_to_nwb reference file.
+                assert current_dio.unit == "N/A"
+                assert ", input=" in current_dio.description
 
     os.remove(filename)
 
@@ -108,7 +111,30 @@ def test_add_dios_two_epoch():
                     rtol=0,
                     atol=1.0 / 30000,
                 )
-                assert current_dio.unit == old_dio.unit
-                assert current_dio.description == old_dio.description
+                # unit is now "N/A" and the description records the header channel
+                # id + input flag (#116, #117), so neither still matches the old
+                # rec_to_nwb reference file.
+                assert current_dio.unit == "N/A"
+                assert ", input=" in current_dio.description
 
     os.remove(filename)
+
+
+def test_add_dios_description_and_unit():
+    # #116/#117: each DIO description carries the specific header channel id and
+    # the input flag with its meaning, and the unit is "N/A".
+    metadata_path = data_path / "20230622_sample_metadata.yml"
+    metadata, _ = convert_yaml.load_metadata(metadata_path, [])
+    nwbfile = convert_yaml.initialize_nwb(metadata, default_test_xml_tree())
+
+    add_dios(nwbfile, [data_path / "20230622_sample_01_a1.rec"], metadata)
+
+    events = nwbfile.processing["behavior"]["behavioral_events"]
+    assert events["Light_1"].description == "ECU_Din1, input=1 (digital input)"
+    assert events["Light_2"].description == "ECU_Din2, input=1 (digital input)"
+    assert events["Poke_1"].description == "ECU_Dout2, input=0 (digital output)"
+    assert all(ts.unit == "N/A" for ts in events.time_series.values())
+    # the human-readable comments from the YAML are preserved, defaulting to
+    # "no comments" when the field is absent (the common case in real metadata)
+    assert events["Light_1"].comments == "Indicator for reward delivery"
+    assert events["Light_2"].comments == "no comments"


### PR DESCRIPTION
Closes #117. Addresses #116 (DIO portion).

## #117 — DIO units + input flag
- `unit="-1"` (a literal `# TODO change to "N/A"`) → **`unit="N/A"`**.
- Add the header `<Channel>` `input` flag to the description, with its meaning.

## #116 — specific header ids in the description
The DIO description was the bare metadata channel name (`"Din1"`). It now uses the **specific hardware channel id from the header** plus the input direction:
```
Light_1 -> "ECU_Din1, input=1 (digital input)"
Poke_1  -> "ECU_Dout2, input=0 (digital output)"
```
(**Why this PR closes #116 despite touching only DIO:** the analog half is already satisfied on `main` — the analog `TimeSeries` description is `"   ".join(analog_channel_ids)` where the ids are the header channel ids (`ECU_Ain1`, `ECU_Ain2`, …). So merging this DIO change resolves #116 in full. (#168 further restructures analog but keeps the ids in the descriptions.))

## What `input` is (verified)
The `input` attribute is the **channel direction** (`1`=digital input, `0`=digital output), uniform across the real headers (every `Din`=1, every `Dout`=0). The 0/1 *data* values are unchanged. The format records the verbatim flag **and** a human gloss, per the chosen best practice.

## Nothing dropped (verified on 98 real metadata files)
Across all 5 rats’ metadata, `behavioral_events` carries only `description` (always `Din*`/`Dout*`) and `name`. The YAML `name` is the **event type** (Light/Poke/Pump per the schema) → stays `TimeSeries.name`; `comments` → stays `TimeSeries.comments`. Only the hardware-provenance `description` changed. **Spyglass keys DIO on `.name`, not `.description`** (`common_behav.py`), so enriching the description is safe.

## Tests
- New `test_add_dios_description_and_unit`: exact descriptions for input + output channels, `unit=="N/A"`, and `comments` preserved.
- Updated the two existing DIO tests (which compared unit/description against the old `rec_to_nwb` reference) to assert the new unit/format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)