### PR TITLE
perf(#47): stream timestamps instead of materialising the full array

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,2 @@
+# machine-specific metrics; regenerated on first run
+bench_47_baseline.json

--- a/benchmarks/bench_47_timestamp_memory.py
+++ b/benchmarks/bench_47_timestamp_memory.py
@@ -31,6 +31,7 @@ import hashlib
 import json
 import os
 import shutil
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -147,6 +148,106 @@ def probe_sample_count_memory(n_samples: int, n_files: int = 2) -> dict:
         "wall_s": wall,
         "extra_rss_bytes": extra,
         "extra_rss_gib": _gib(extra),
+    }
+
+
+class _RegressionBackedIO:
+    """Stand-in for SpikeGadgetsRawIO that computes regressed timestamps on demand.
+
+    ``get_regressed_systime(i_start, i_stop)`` returns a freshly-computed
+    ``float64`` slice (the way the real reader derives each chunk from cached fit
+    parameters), so the full timestamps array is never held resident -- exactly
+    the behaviour ``_LazyTimestamps`` relies on.
+    """
+
+    sysClock_byte = True
+
+    def __init__(self, lo: int, hi: int):
+        self._lo, self._hi = lo, hi
+        # only shape[0] (the file's sample count) is read by the lazy path
+        self._raw_memmap = np.empty((hi - lo, 0), dtype=np.uint8)
+
+    def get_regressed_systime(self, i_start, i_stop=None):
+        i_start = 0 if i_start is None else i_start
+        i_stop = (self._hi - self._lo) if i_stop is None else i_stop
+        return (
+            np.arange(self._lo + i_start, self._lo + i_stop, dtype=np.float64)
+            / EPHYS_RATE_HZ
+        )
+
+
+def probe_eseries_timestamps_memory(
+    n_samples: int, n_files: int = 2, buffer_mib: float = 32.0
+) -> dict:
+    """Measure that the e-series timestamps are no longer materialised (#47, step 2).
+
+    Pre-#47, ``RecFileDataChunkIterator.timestamps`` was
+    ``np.concatenate([io.get_regressed_systime(0, None) ...])`` -- the whole
+    ``n_samples * 8`` byte ``float64`` array, held resident from the iterator's
+    construction until the NWB file was written (effectively the whole
+    conversion). This probe builds the real ``_LazyTimestamps`` over on-demand
+    files and then writes it through the real chunked-write path
+    (``as_data_chunk_iterator`` -> hdmf iterative writer), reporting:
+
+    - ``build_extra``      resident bytes the lazy representation adds (~0 vs the
+      full array it replaces), and
+    - ``write_peak_extra`` peak extra RSS during the streamed write, bounded by
+      the iterator buffer rather than ``n_samples``.
+    """
+    from datetime import datetime
+
+    from pynwb import NWBHDF5IO, NWBFile, TimeSeries
+
+    from trodes_to_nwb.convert_ephys import _LazyTimestamps
+
+    edges = np.linspace(0, n_samples, n_files + 1, dtype=np.int64)
+    ios = [
+        _RegressionBackedIO(int(edges[i]), int(edges[i + 1])) for i in range(n_files)
+    ]
+
+    # (a) building the lazy representation -- should add ~0 resident bytes
+    with PeakRSS() as rss_build:
+        lazy = _LazyTimestamps(ios, use_sysclock=True)
+    build_extra = rss_build.delta
+
+    # (b) streamed write -- peak bounded by the iterator buffer, not n_samples.
+    #     Write the timestamps as a TimeSeries's data via the same hdmf iterative
+    #     path the real timestamps dataset uses; a small buffer makes the
+    #     streaming visible at a probe-affordable n_samples.
+    buffer_gb = buffer_mib / 1024.0
+    scratch = Path(tempfile.mkdtemp(prefix="bench47_ts_"))
+    nwb_path = scratch / "eseries_timestamps_probe.nwb"
+    nwbfile = NWBFile(
+        session_description="bench",
+        identifier="bench",
+        session_start_time=datetime(2023, 1, 1),
+    )
+    nwbfile.add_acquisition(
+        TimeSeries(
+            name="eseries_timestamps_probe",
+            data=lazy.as_data_chunk_iterator(buffer_gb=buffer_gb),
+            rate=float(EPHYS_RATE_HZ),
+            unit="seconds",
+        )
+    )
+    try:
+        with PeakRSS() as rss_write:
+            start = time.perf_counter()
+            with NWBHDF5IO(str(nwb_path), "w") as io:
+                io.write(nwbfile)
+            wall = time.perf_counter() - start
+        write_peak_extra = rss_write.delta
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    full = n_samples * 8  # bytes the old np.concatenate held resident
+    return {
+        "n_samples": n_samples,
+        "wall_s": wall,
+        "old_resident_gib": _gib(full),
+        "build_extra_gib": _gib(build_extra),
+        "write_peak_extra_gib": _gib(write_peak_extra),
+        "buffer_mib": buffer_mib,
     }
 
 
@@ -289,7 +390,23 @@ def main() -> int:
         f"({factor:.1f}x): {probe['extra_rss_gib'] * factor:.1f} GiB"
     )
 
-    result: dict = {"scale_probe": {k: v for k, v in probe.items() if k != "_held"}}
+    ts_probe = probe_eseries_timestamps_memory(n)
+    print(f"\n[e-series timestamps memory probe]  N = {n:,} samples")
+    print(
+        f"  old array held resident    : {ts_probe['old_resident_gib']:.3f} GiB"
+        f"  (extrapolates to {ts_probe['old_resident_gib'] * factor:.1f} GiB @ "
+        f"{REFERENCE_HOURS:g} h)"
+    )
+    print(f"  lazy build extra RSS       : {ts_probe['build_extra_gib']:.3f} GiB")
+    print(
+        f"  streamed write peak extra  : {ts_probe['write_peak_extra_gib']:.3f} GiB"
+        f"  ({ts_probe['buffer_mib']:.0f} MiB buffer; bounded, not N)"
+    )
+
+    result: dict = {
+        "scale_probe": {k: v for k, v in probe.items() if k != "_held"},
+        "eseries_timestamps_probe": ts_probe,
+    }
 
     # --- end-to-end conversion: speed, memory, equivalence -------------------
     if not args.skip_full:

--- a/benchmarks/bench_47_timestamp_memory.py
+++ b/benchmarks/bench_47_timestamp_memory.py
@@ -1,0 +1,322 @@
+"""Benchmark + equivalence harness for issue #47 (avoid loading all timestamps
+into memory).
+
+Two things, run together:
+
+1. **Baseline + regression of speed and memory.** Runs the real end-to-end
+   conversion on the bundled sample data and reports wall time and peak RSS, plus
+   a synthetic at-scale probe of the `sample_count` materialisation (the
+   conflict-free #47 surface in ``convert_intervals.add_sample_count``) so the
+   memory win is visible even though the sample data is tiny.
+
+2. **"Don't change the answer" guard.** Fingerprints the key datasets of the
+   produced NWB (sha1 of the raw bytes). The first run writes
+   ``bench_47_baseline.json``; later runs compare against it and FAIL loudly if
+   any dataset changed. Any #47 refactor must keep every fingerprint identical.
+
+Usage::
+
+    python benchmarks/bench_47_timestamp_memory.py            # run + compare (or seed baseline)
+    python benchmarks/bench_47_timestamp_memory.py --reseed   # overwrite the baseline
+    python benchmarks/bench_47_timestamp_memory.py --scale 1e8 --skip-full   # memory probe only
+
+This is a developer tool, not part of the test suite (it is slow and its
+absolute numbers are machine-dependent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+import psutil
+
+HERE = Path(__file__).resolve().parent
+BASELINE_PATH = HERE / "bench_47_baseline.json"
+SECONDS_PER_HOUR = 3600
+EPHYS_RATE_HZ = 30_000
+REFERENCE_HOURS = 17.0  # the duration called out in issue #47
+
+
+class PeakRSS:
+    """Context manager sampling process RSS on a background thread.
+
+    ``peak`` is the maximum resident set size (bytes) observed between enter and
+    exit, and ``delta`` subtracts the RSS at entry so it reports the *extra*
+    memory the wrapped work brought resident.
+    """
+
+    def __init__(self, interval: float = 0.005):
+        self.interval = interval
+        self._proc = psutil.Process()
+        self._stop = False
+        self.start_rss = 0
+        self.peak = 0
+
+    def __enter__(self) -> "PeakRSS":
+        self.start_rss = self._proc.memory_info().rss
+        self.peak = self.start_rss
+        self._thread = threading.Thread(target=self._sample, daemon=True)
+        self._thread.start()
+        return self
+
+    def _sample(self) -> None:
+        while not self._stop:
+            self.peak = max(self.peak, self._proc.memory_info().rss)
+            time.sleep(self.interval)
+
+    def __exit__(self, *_exc) -> None:
+        self._stop = True
+        self._thread.join()
+        self.peak = max(self.peak, self._proc.memory_info().rss)
+
+    @property
+    def delta(self) -> int:
+        return self.peak - self.start_rss
+
+
+def _gib(n_bytes: float) -> float:
+    return n_bytes / 1024**3
+
+
+# --------------------------------------------------------------------------- #
+# 1. Synthetic at-scale probe of the sample_count materialisation
+# --------------------------------------------------------------------------- #
+class _DiskBackedIO:
+    """Stand-in for SpikeGadgetsRawIO that yields Trodes sample counts on demand
+    (``np.arange``), the way the real reader streams them from the memmap rather
+    than holding them resident."""
+
+    def __init__(self, lo: int, hi: int):
+        self._lo, self._hi = lo, hi
+        # only shape[0] (the file's sample count) is read by the lazy path
+        self._raw_memmap = np.empty((hi - lo, 0), dtype=np.uint8)
+
+    def get_analogsignal_timestamps(self, i_start, i_stop):
+        i_start = 0 if i_start is None else i_start
+        i_stop = (self._hi - self._lo) if i_stop is None else i_stop
+        return np.arange(self._lo + i_start, self._lo + i_stop, dtype=np.uint32)
+
+
+def probe_sample_count_memory(n_samples: int, n_files: int = 2) -> dict:
+    """Measure the *extra* resident memory the real ``add_sample_count`` brings.
+
+    Calls the actual function (so it auto-reflects the refactor) with a rec_dci
+    whose ``timestamps`` is the already-resident ephys array and whose Trodes
+    sample counts are generated on demand (simulating the on-disk memmap). The
+    measured delta is everything ``add_sample_count`` adds on top of the shared
+    timestamps — i.e. exactly what #47 is about.
+    """
+    from datetime import datetime
+
+    from pynwb import NWBFile
+
+    from trodes_to_nwb.convert_intervals import add_sample_count
+
+    shared_timestamps = np.linspace(
+        0.0, n_samples / EPHYS_RATE_HZ, n_samples, dtype=np.float64
+    )
+    edges = np.linspace(0, n_samples, n_files + 1, dtype=np.int64)
+
+    class _RecDci:
+        timestamps = shared_timestamps
+        neo_io = [
+            _DiskBackedIO(int(edges[i]), int(edges[i + 1])) for i in range(n_files)
+        ]
+
+    nwbfile = NWBFile(
+        session_description="bench",
+        identifier="bench",
+        session_start_time=datetime(2023, 1, 1),
+    )
+    with PeakRSS() as rss:
+        start = time.perf_counter()
+        add_sample_count(nwbfile, _RecDci())
+        wall = time.perf_counter() - start
+
+    extra = rss.delta
+    return {
+        "n_samples": n_samples,
+        "wall_s": wall,
+        "extra_rss_bytes": extra,
+        "extra_rss_gib": _gib(extra),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# 2. End-to-end conversion: speed, memory, and output fingerprint
+# --------------------------------------------------------------------------- #
+def _fingerprint_array(arr) -> dict:
+    a = np.ascontiguousarray(arr[:])
+    return {
+        "shape": list(a.shape),
+        "dtype": str(a.dtype),
+        "sha1": hashlib.sha1(a.tobytes()).hexdigest(),
+    }
+
+
+def fingerprint_nwb(path: Path) -> dict:
+    """Hash the datasets a #47 timestamp refactor could plausibly perturb."""
+    import pynwb
+
+    fp: dict = {}
+    with pynwb.NWBHDF5IO(str(path), "r", load_namespaces=True) as io:
+        nwb = io.read()
+        es = nwb.acquisition["e-series"]
+        fp["eseries.data"] = _fingerprint_array(es.data)
+        fp["eseries.timestamps"] = _fingerprint_array(es.timestamps)
+        if "sample_count" in nwb.processing:
+            sc = nwb.processing["sample_count"]["sample_count"]
+            fp["sample_count.data"] = _fingerprint_array(sc.data)
+            fp["sample_count.timestamps"] = _fingerprint_array(sc.timestamps)
+        if "analog" in nwb.processing:
+            an = nwb.processing["analog"]["analog"]["analog"]
+            fp["analog.data"] = _fingerprint_array(an.data)
+            fp["analog.timestamps"] = _fingerprint_array(an.timestamps)
+        if "behavior" in nwb.processing:
+            be = nwb.processing["behavior"]["behavioral_events"]
+            for name, ts in sorted(be.time_series.items()):
+                fp[f"dio.{name}.data"] = _fingerprint_array(ts.data)
+                fp[f"dio.{name}.timestamps"] = _fingerprint_array(ts.timestamps)
+    return fp
+
+
+def run_full_conversion() -> tuple[Path, dict]:
+    """Run the bundled sample conversion (mirrors test_convert_full) under
+    peak-RSS + wall-time measurement; returns the output path and metrics."""
+    from trodes_to_nwb.convert import create_nwbs, get_included_device_metadata_paths
+    from trodes_to_nwb.tests.utils import data_path
+
+    device_metadata = get_included_device_metadata_paths()
+    video_directory = data_path / "temp_video_directory_bench47"
+    video_directory.mkdir(exist_ok=True)
+    exclude = str(data_path / "20230622_sample_metadataProbeReconfig.yml")
+
+    with PeakRSS() as rss:
+        start = time.perf_counter()
+        create_nwbs(
+            path=data_path,
+            device_metadata_paths=device_metadata,
+            output_dir=str(data_path),
+            n_workers=1,
+            query_expression=f"animal == 'sample' and full_path != '{exclude}'",
+            fs_gui_dir=data_path,
+        )
+        wall = time.perf_counter() - start
+
+    output = data_path / "sample20230622.nwb"
+    metrics = {
+        "wall_s": wall,
+        "peak_rss_bytes": rss.peak,
+        "peak_rss_gib": _gib(rss.peak),
+    }
+    # tidy the report file + scratch dir; keep the nwb until after fingerprinting
+    report = data_path / "sample20230622_nwbinspector_report.txt"
+    if report.exists():
+        report.unlink()
+    shutil.rmtree(video_directory, ignore_errors=True)
+    return output, metrics
+
+
+def compare_fingerprints(baseline: dict, current: dict) -> list[str]:
+    diffs = []
+    for key in sorted(set(baseline) | set(current)):
+        b, c = baseline.get(key), current.get(key)
+        if b is None:
+            diffs.append(f"  + {key}: present now, absent in baseline")
+        elif c is None:
+            diffs.append(f"  - {key}: in baseline, absent now")
+        elif b != c:
+            diffs.append(f"  ~ {key}: {b} -> {c}")
+    return diffs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--scale",
+        type=float,
+        default=1e8,
+        help="synthetic sample count for the memory probe (default 1e8)",
+    )
+    ap.add_argument(
+        "--skip-full",
+        action="store_true",
+        help="skip the end-to-end conversion (memory probe only)",
+    )
+    ap.add_argument(
+        "--reseed",
+        action="store_true",
+        help="overwrite the saved fingerprint/metrics baseline",
+    )
+    args = ap.parse_args()
+
+    print("=" * 72)
+    print("Issue #47 benchmark: timestamp / sample_count memory")
+    print("=" * 72)
+
+    # --- synthetic at-scale memory probe -------------------------------------
+    n = int(args.scale)
+    probe = probe_sample_count_memory(n)
+    factor = (REFERENCE_HOURS * SECONDS_PER_HOUR * EPHYS_RATE_HZ) / n
+    print(f"\n[sample_count memory probe]  N = {n:,} samples")
+    print(
+        f"  add_sample_count extra RSS : {probe['extra_rss_gib']:.3f} GiB"
+        f"  ({probe['wall_s'] * 1e3:.0f} ms)"
+    )
+    print(
+        f"  extrapolated to {REFERENCE_HOURS:g} h @ {EPHYS_RATE_HZ // 1000} kHz "
+        f"({factor:.1f}x): {probe['extra_rss_gib'] * factor:.1f} GiB"
+    )
+
+    result: dict = {"scale_probe": {k: v for k, v in probe.items() if k != "_held"}}
+
+    # --- end-to-end conversion: speed, memory, equivalence -------------------
+    if not args.skip_full:
+        output, metrics = run_full_conversion()
+        print(f"\n[full sample conversion]")
+        print(f"  wall time : {metrics['wall_s']:.1f} s")
+        print(f"  peak RSS  : {metrics['peak_rss_gib']:.3f} GiB")
+        fp = fingerprint_nwb(output)
+        result["full_metrics"] = metrics
+        result["fingerprint"] = fp
+        output.unlink(missing_ok=True)
+
+        # equivalence check vs saved baseline
+        if BASELINE_PATH.exists() and not args.reseed:
+            base = json.loads(BASELINE_PATH.read_text())
+            diffs = compare_fingerprints(base.get("fingerprint", {}), fp)
+            print(f"\n[equivalence vs baseline]  ({len(fp)} datasets)")
+            if diffs:
+                print("  ANSWER CHANGED:")
+                print("\n".join(diffs))
+                return 1
+            print("  OK - every dataset fingerprint matches the baseline.")
+            bm = base.get("full_metrics", {})
+            if bm:
+                dt = metrics["wall_s"] - bm["wall_s"]
+                dm = metrics["peak_rss_gib"] - bm["peak_rss_gib"]
+                print(f"  speed  Δ {dt:+.1f} s (baseline {bm['wall_s']:.1f} s)")
+                print(
+                    f"  memory Δ {dm:+.3f} GiB (baseline {bm['peak_rss_gib']:.3f} GiB)"
+                )
+            return 0
+
+    if not BASELINE_PATH.exists() or args.reseed:
+        BASELINE_PATH.write_text(json.dumps(result, indent=2))
+        print(
+            f"\nSeeded baseline -> {BASELINE_PATH.name}"
+            + (" (fingerprint included)" if "fingerprint" in result else "")
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bench_47_timestamp_memory.py
+++ b/benchmarks/bench_47_timestamp_memory.py
@@ -163,28 +163,41 @@ def _fingerprint_array(arr) -> dict:
 
 
 def fingerprint_nwb(path: Path) -> dict:
-    """Hash the datasets a #47 timestamp refactor could plausibly perturb."""
+    """Hash the data + timestamps of *every* TimeSeries-like object in the file.
+
+    A generic walk (rather than hard-coded paths) so the golden master can't
+    silently miss a dataset when the NWB layout changes -- e.g. #168 moved analog
+    from ``processing/analog`` into separate ``acquisition`` series. Linking a
+    series' timestamps to another (a #47 optimisation) reads back the same values
+    through the HDF5 link, so a correct link leaves the fingerprint unchanged.
+    """
     import pynwb
 
     fp: dict = {}
+
+    def add(label: str, obj) -> None:
+        if getattr(obj, "data", None) is not None:
+            fp[f"{label}.data"] = _fingerprint_array(obj.data)
+        if getattr(obj, "timestamps", None) is not None:
+            fp[f"{label}.timestamps"] = _fingerprint_array(obj.timestamps)
+
+    def walk(label: str, obj) -> None:
+        if hasattr(obj, "time_series"):  # BehavioralEvents / BehavioralTimeSeries
+            for name, ts in sorted(obj.time_series.items()):
+                walk(f"{label}.{name}", ts)
+        elif hasattr(obj, "spatial_series"):  # Position / CompassDirection
+            for name, ss in sorted(obj.spatial_series.items()):
+                walk(f"{label}.{name}", ss)
+        else:
+            add(label, obj)
+
     with pynwb.NWBHDF5IO(str(path), "r", load_namespaces=True) as io:
         nwb = io.read()
-        es = nwb.acquisition["e-series"]
-        fp["eseries.data"] = _fingerprint_array(es.data)
-        fp["eseries.timestamps"] = _fingerprint_array(es.timestamps)
-        if "sample_count" in nwb.processing:
-            sc = nwb.processing["sample_count"]["sample_count"]
-            fp["sample_count.data"] = _fingerprint_array(sc.data)
-            fp["sample_count.timestamps"] = _fingerprint_array(sc.timestamps)
-        if "analog" in nwb.processing:
-            an = nwb.processing["analog"]["analog"]["analog"]
-            fp["analog.data"] = _fingerprint_array(an.data)
-            fp["analog.timestamps"] = _fingerprint_array(an.timestamps)
-        if "behavior" in nwb.processing:
-            be = nwb.processing["behavior"]["behavioral_events"]
-            for name, ts in sorted(be.time_series.items()):
-                fp[f"dio.{name}.data"] = _fingerprint_array(ts.data)
-                fp[f"dio.{name}.timestamps"] = _fingerprint_array(ts.timestamps)
+        for name, obj in sorted(nwb.acquisition.items()):
+            walk(f"acq.{name}", obj)
+        for mod_name, mod in sorted(nwb.processing.items()):
+            for di_name, di in sorted(mod.data_interfaces.items()):
+                walk(f"{mod_name}.{di_name}", di)
     return fp
 
 

--- a/benchmarks/bench_47_timestamp_memory.py
+++ b/benchmarks/bench_47_timestamp_memory.py
@@ -90,20 +90,30 @@ def _gib(n_bytes: float) -> float:
 # --------------------------------------------------------------------------- #
 # 1. Synthetic at-scale probe of the sample_count materialisation
 # --------------------------------------------------------------------------- #
-class _DiskBackedIO:
-    """Stand-in for SpikeGadgetsRawIO that yields Trodes sample counts on demand
-    (``np.arange``), the way the real reader streams them from the memmap rather
-    than holding them resident."""
+class _FakeStreamIO:
+    """Stand-in for SpikeGadgetsRawIO that yields values on demand (``np.arange``),
+    the way the real reader streams them from the memmap rather than holding them
+    resident. Exposes both reader methods so it serves the sample_count probe
+    (``get_analogsignal_timestamps``, uint32) and the e-series probe
+    (``get_regressed_systime``, float64)."""
+
+    sysClock_byte = True
 
     def __init__(self, lo: int, hi: int):
         self._lo, self._hi = lo, hi
         # only shape[0] (the file's sample count) is read by the lazy path
         self._raw_memmap = np.empty((hi - lo, 0), dtype=np.uint8)
 
-    def get_analogsignal_timestamps(self, i_start, i_stop):
+    def _range(self, i_start, i_stop):
         i_start = 0 if i_start is None else i_start
         i_stop = (self._hi - self._lo) if i_stop is None else i_stop
-        return np.arange(self._lo + i_start, self._lo + i_stop, dtype=np.uint32)
+        return np.arange(self._lo + i_start, self._lo + i_stop)
+
+    def get_analogsignal_timestamps(self, i_start, i_stop):
+        return self._range(i_start, i_stop).astype(np.uint32)
+
+    def get_regressed_systime(self, i_start, i_stop=None):
+        return self._range(i_start, i_stop).astype(np.float64) / EPHYS_RATE_HZ
 
 
 def probe_sample_count_memory(n_samples: int, n_files: int = 2) -> dict:
@@ -129,7 +139,7 @@ def probe_sample_count_memory(n_samples: int, n_files: int = 2) -> dict:
     class _RecDci:
         timestamps = shared_timestamps
         neo_io = [
-            _DiskBackedIO(int(edges[i]), int(edges[i + 1])) for i in range(n_files)
+            _FakeStreamIO(int(edges[i]), int(edges[i + 1])) for i in range(n_files)
         ]
 
     nwbfile = NWBFile(
@@ -149,31 +159,6 @@ def probe_sample_count_memory(n_samples: int, n_files: int = 2) -> dict:
         "extra_rss_bytes": extra,
         "extra_rss_gib": _gib(extra),
     }
-
-
-class _RegressionBackedIO:
-    """Stand-in for SpikeGadgetsRawIO that computes regressed timestamps on demand.
-
-    ``get_regressed_systime(i_start, i_stop)`` returns a freshly-computed
-    ``float64`` slice (the way the real reader derives each chunk from cached fit
-    parameters), so the full timestamps array is never held resident -- exactly
-    the behaviour ``_LazyTimestamps`` relies on.
-    """
-
-    sysClock_byte = True
-
-    def __init__(self, lo: int, hi: int):
-        self._lo, self._hi = lo, hi
-        # only shape[0] (the file's sample count) is read by the lazy path
-        self._raw_memmap = np.empty((hi - lo, 0), dtype=np.uint8)
-
-    def get_regressed_systime(self, i_start, i_stop=None):
-        i_start = 0 if i_start is None else i_start
-        i_stop = (self._hi - self._lo) if i_stop is None else i_stop
-        return (
-            np.arange(self._lo + i_start, self._lo + i_stop, dtype=np.float64)
-            / EPHYS_RATE_HZ
-        )
 
 
 def probe_eseries_timestamps_memory(
@@ -201,9 +186,7 @@ def probe_eseries_timestamps_memory(
     from trodes_to_nwb.convert_ephys import _LazyTimestamps
 
     edges = np.linspace(0, n_samples, n_files + 1, dtype=np.int64)
-    ios = [
-        _RegressionBackedIO(int(edges[i]), int(edges[i + 1])) for i in range(n_files)
-    ]
+    ios = [_FakeStreamIO(int(edges[i]), int(edges[i + 1])) for i in range(n_files)]
 
     # (a) building the lazy representation -- should add ~0 resident bytes
     with PeakRSS() as rss_build:

--- a/src/trodes_to_nwb/convert_analog.py
+++ b/src/trodes_to_nwb/convert_analog.py
@@ -9,7 +9,7 @@ from hdmf.backends.hdf5 import H5DataIO
 from pynwb import NWBFile
 
 from trodes_to_nwb import convert_rec_header
-from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator, _timestamps_for_write
 
 DEFAULT_CHUNK_TIME_DIM = 16384
 DEFAULT_CHUNK_MAX_CHANNEL_DIM = 32
@@ -96,7 +96,9 @@ def add_analog_data(
                 analog_channel_ids
             ),  # NOTE: matches rec_to_nwb system
             data=data_data_io,
-            timestamps=rec_dci.timestamps,
+            # rec_dci.timestamps is a lazy virtual array (#47); stream it like the
+            # e-series/sample_count writers do (a bare lazy array is rejected by docval).
+            timestamps=_timestamps_for_write(rec_dci.timestamps),
             unit="-1",
         )
     )

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -54,6 +54,184 @@ def _is_strictly_increasing(values, chunk_size: int = 1_000_000) -> bool:
     return True
 
 
+class _LazyTimestamps:
+    """Virtual, read-only 1-D ``float64`` timestamps spanning all rec files.
+
+    Replaces the eager
+    ``np.concatenate([io.get_regressed_systime(0, None) for io in neo_io])`` that
+    held the whole timestamps array (~14.7 GB at 17 h @30 kHz) resident for the
+    entire conversion (#47). Each requested slice / index is computed on demand
+    from the per-file counter->system-clock regression (or the Trodes-timestamp
+    fallback for non-sysClock files), so the full array is never materialised.
+
+    Values are **byte-identical** to the old concatenation: every timestamp is
+    ``intercept + slope * unwrapped_counter`` (sysClock path) or
+    ``(counter - counter0) / rate + t_creation`` (fallback). Both are elementwise
+    and independent of how the array is chunked, and ``get_regressed_systime`` /
+    ``get_systime_from_trodes_timestamps`` already support arbitrary sub-ranges
+    (including across uint32 wraps) and cache the fit, so a per-file sub-range
+    read returns exactly the same bytes as the whole-file read sliced.
+
+    Supported access -- one per consumer of ``RecFileDataChunkIterator.timestamps``:
+
+    - ``ts[a:b]``        contiguous slice  -> chunked writes; the monotonicity scan
+    - ``ts[int_array]``  integer fancy index -> decimated headstage sensor timestamps
+    - ``ts[i]``          scalar
+    - ``np.asarray(ts)`` full materialise -> ``np.digitize`` / ``np.concatenate``
+      (the non-PTP position path; step 3 removes that last full materialisation)
+
+    For chunk-by-chunk HDF5 writes use :meth:`as_data_chunk_iterator` (a
+    ``GenericDataChunkIterator``); pynwb writes a plain array via ``data[:]`` in
+    one shot (which would call ``__array__`` and re-materialise the whole array),
+    but streams an ``AbstractDataChunkIterator``.
+    """
+
+    def __init__(self, neo_io: list, use_sysclock: bool):
+        self._neo_io = list(neo_io)
+        self._use_sysclock = use_sysclock
+        # Per-file length is the file's packet count -- exactly the length of the
+        # old per-file ``get_regressed_systime(0, None)``. For interpolating
+        # iterators this must be read *after* interpolation is resolved (the
+        # caller triggers it; _get_signal_size raises otherwise).
+        lengths = [io._raw_memmap.shape[0] for io in self._neo_io]
+        self._starts = np.concatenate([[0], np.cumsum(lengths)]).astype(np.int64)
+        self._total = int(self._starts[-1])
+
+    # --- numpy-array-like surface -------------------------------------------
+    def __len__(self) -> int:
+        return self._total
+
+    @property
+    def shape(self) -> tuple[int]:
+        return (self._total,)
+
+    @property
+    def size(self) -> int:
+        return self._total
+
+    @property
+    def ndim(self) -> int:
+        return 1
+
+    @property
+    def dtype(self) -> np.dtype:
+        return np.dtype("float64")
+
+    # --- on-demand computation ----------------------------------------------
+    def _read_file(self, file_index: int, lo: int, hi: int) -> np.ndarray:
+        """Timestamps for file ``file_index`` over its local range ``[lo, hi)``."""
+        io = self._neo_io[file_index]
+        if self._use_sysclock:
+            values = io.get_regressed_systime(lo, hi)
+        else:
+            values = io.get_systime_from_trodes_timestamps(lo, hi)
+        return np.asarray(values, dtype=np.float64)
+
+    def _slice(self, start: int, stop: int) -> np.ndarray:
+        """Contiguous values for the global half-open range ``[start, stop)``."""
+        start = max(0, min(start, self._total))
+        stop = max(start, min(stop, self._total))
+        if stop == start:
+            return np.empty(0, dtype=np.float64)
+        first = int(np.searchsorted(self._starts, start, side="right") - 1)
+        parts = []
+        for file_index in range(first, len(self._neo_io)):
+            file_start = int(self._starts[file_index])
+            if file_start >= stop:
+                break
+            file_stop = int(self._starts[file_index + 1])
+            lo = max(start, file_start) - file_start
+            hi = min(stop, file_stop) - file_start
+            parts.append(self._read_file(file_index, lo, hi))
+        return parts[0] if len(parts) == 1 else np.concatenate(parts)
+
+    def _gather(self, indices: np.ndarray) -> np.ndarray:
+        """Fancy index: load only the spanned contiguous range, then index into it.
+
+        Headstage update indices are sparse but confined to a single file, so the
+        spanned range is one file's worth of timestamps (a few MB), never the
+        whole recording.
+        """
+        indices = np.asarray(indices)
+        if indices.dtype == bool:
+            indices = np.flatnonzero(indices)
+        indices = indices.astype(np.int64, copy=False)
+        if indices.size == 0:
+            return np.empty(0, dtype=np.float64)
+        if (indices < 0).any():
+            indices = np.where(indices < 0, indices + self._total, indices)
+        lo = int(indices.min())
+        hi = int(indices.max())
+        block = self._slice(lo, hi + 1)
+        return block[indices - lo]
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            start, stop, step = key.indices(self._total)
+            if step == 1:
+                return self._slice(start, stop)
+            # Non-unit step (never used on the big arrays in practice): load the
+            # spanned range once, then stride, so we still never materialise more
+            # than the covered span.
+            return self._gather(np.arange(start, stop, step))
+        if isinstance(key, (int, np.integer)):
+            i = int(key)
+            if i < 0:
+                i += self._total
+            if not 0 <= i < self._total:
+                raise IndexError(f"index {key} out of range for length {self._total}")
+            return self._slice(i, i + 1)[0]
+        # integer (or boolean) array fancy indexing
+        return self._gather(key)
+
+    def __array__(self, dtype=None, copy=None) -> np.ndarray:
+        out = self._slice(0, self._total)
+        if dtype is not None:
+            out = out.astype(dtype, copy=False)
+        return out
+
+    def as_data_chunk_iterator(self, **kwargs) -> "_LazyTimestampsChunkIterator":
+        """A ``GenericDataChunkIterator`` for streaming these timestamps to HDF5."""
+        return _LazyTimestampsChunkIterator(self, **kwargs)
+
+
+class _LazyTimestampsChunkIterator(GenericDataChunkIterator):
+    """Stream a :class:`_LazyTimestamps` into HDF5 one chunk at a time.
+
+    pynwb writes a plain array-like via ``data[:]`` -- one shot, re-materialising
+    the whole ~14.7 GB-at-17h timestamps array. Only an
+    ``AbstractDataChunkIterator`` is written iteratively, so the big-timestamp
+    datasets (e-series / ECU analog / sample_count) are wrapped here to be
+    written without ever holding the full array resident (#47).
+    """
+
+    def __init__(self, lazy: "_LazyTimestamps", **kwargs):
+        self._lazy = lazy
+        super().__init__(**kwargs)
+
+    def _get_data(self, selection: tuple) -> np.ndarray:
+        return self._lazy[selection[0]]
+
+    def _get_maxshape(self) -> tuple[int]:
+        return (len(self._lazy),)
+
+    def _get_dtype(self) -> np.dtype:
+        return np.dtype("float64")
+
+
+def _timestamps_for_write(timestamps):
+    """Return a chunked iterator for lazy timestamps, else the value unchanged.
+
+    A :class:`_LazyTimestamps` must be written through a ``DataChunkIterator`` so
+    pynwb streams the dataset instead of calling ``__array__`` and re-materialising
+    the whole array (#47). A plain array (e.g. the small decimated sensor
+    timestamps, or timestamps supplied by the caller) is written as-is.
+    """
+    if isinstance(timestamps, _LazyTimestamps):
+        return timestamps.as_data_chunk_iterator()
+    return timestamps
+
+
 class RecFileDataChunkIterator(GenericDataChunkIterator):
     """Data chunk iterator for SpikeGadgets rec files."""
 
@@ -219,22 +397,29 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 self.neo_io.pop(iterator_loc)
                 self.neo_io[iterator_loc:iterator_loc] = sub_iterators
         logger.info(f"# iterators: {len(self.neo_io)}")
-        # NOTE: this will read all the timestamps from the rec file, which can be slow
+        # Resolve dropped-packet interpolation up front. Before #47 this happened
+        # as a side effect of materialising the timestamps below; now that the
+        # timestamps are lazy we trigger it explicitly so each file's interpolated
+        # length is final before _LazyTimestamps and self.n_time read it
+        # (_get_signal_size raises if interpolation is enabled but unresolved).
+        # This first call scans only the uint32 counter, never the float64
+        # timestamps. Split (partial) iterators already resolve it in __init__.
+        for neo_io in self.neo_io:
+            if getattr(neo_io, "interpolate_dropped_packets", False) and (
+                getattr(neo_io, "interpolate_index", None) is None
+            ):
+                neo_io.get_analogsignal_timestamps(0, 1)
+
+        # Timestamps are built lazily (#47): a virtual array that computes each
+        # requested slice / index on demand from the per-file clock regression,
+        # instead of concatenating every file's full timestamps (~14.7 GB at 17 h)
+        # up front. Values are byte-identical to the old concatenation.
         if timestamps is not None:
             self.timestamps = timestamps
-
         elif self.neo_io[0].sysClock_byte:  # use this if have sysClock
-            self.timestamps = np.concatenate(
-                [neo_io.get_regressed_systime(0, None) for neo_io in self.neo_io]
-            )
-
+            self.timestamps = _LazyTimestamps(self.neo_io, use_sysclock=True)
         else:  # use this to convert Trodes timestamps into systime based on sampling rate
-            self.timestamps = np.concatenate(
-                [
-                    neo_io.get_systime_from_trodes_timestamps(0, None)
-                    for neo_io in self.neo_io
-                ]
-            )
+            self.timestamps = _LazyTimestamps(self.neo_io, use_sysclock=False)
 
         logger.info("Reading timestamps COMPLETE")
         # Must be strictly increasing. `np.all(np.diff(...))` only checks that no
@@ -432,7 +617,9 @@ def add_raw_ephys(
     eseries = ElectricalSeries(
         name="e-series",
         data=data_data_io,
-        timestamps=rec_dci.timestamps,
+        # Stream the timestamps dataset chunk-by-chunk (#47); a bare array here
+        # would re-materialise the whole ~14.7 GB-at-17h timestamps on write.
+        timestamps=_timestamps_for_write(rec_dci.timestamps),
         electrodes=electrode_table_region,  # TODO
         conversion=VOLTS_PER_MICROVOLT,
         offset=0.0,  # TODO

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -54,6 +54,27 @@ def _is_strictly_increasing(values, chunk_size: int = 1_000_000) -> bool:
     return True
 
 
+def _is_non_decreasing(values, chunk_size: int = 1_000_000) -> bool:
+    """Return whether ``values`` never decreases, streaming in chunks.
+
+    Like :func:`_is_strictly_increasing` but with ``>= 0`` rather than ``> 0`` --
+    it allows equal neighbours. This is exactly ``np.digitize``'s monotonic-bins
+    precondition, so the lazy digitize path can fail loud on a backward jump (a
+    clock reset) while still accepting duplicate timestamps, matching the old
+    materialised ``np.digitize`` behaviour (#47).
+    """
+    n = len(values)
+    if n < 2:
+        return True
+    previous = values[0]
+    for start in range(1, n, chunk_size):
+        block = np.asarray(values[start : start + chunk_size])
+        if block[0] < previous or not np.all(np.diff(block) >= 0):
+            return False
+        previous = block[-1]
+    return True
+
+
 class _LazyTimestamps:
     """Virtual, read-only 1-D ``float64`` timestamps spanning all rec files.
 
@@ -99,6 +120,7 @@ class _LazyTimestamps:
         lengths = [io._raw_memmap.shape[0] for io in self._neo_io]
         self._starts = np.concatenate([[0], np.cumsum(lengths)]).astype(np.int64)
         self._total = int(self._starts[-1])
+        self._non_decreasing = None  # lazily computed + cached (is_non_decreasing)
 
     # --- numpy-array-like surface -------------------------------------------
     def __len__(self) -> int:
@@ -119,6 +141,18 @@ class _LazyTimestamps:
     @property
     def dtype(self) -> np.dtype:
         return np.dtype("float64")
+
+    def is_non_decreasing(self) -> bool:
+        """Whether the timestamps never decrease (``np.digitize``'s precondition).
+
+        Streamed (never materialises the full array) and cached. Allows
+        duplicates and fails only on an actual backward jump, so the lazy
+        digitize path (non-PTP position) can fail loud on a clock reset exactly
+        where the old materialised ``np.digitize`` would have raised (#47).
+        """
+        if self._non_decreasing is None:
+            self._non_decreasing = _is_non_decreasing(self)
+        return self._non_decreasing
 
     # --- on-demand computation ----------------------------------------------
     def _read_file(self, file_index: int, lo: int, hi: int) -> np.ndarray:

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -135,10 +135,6 @@ class _LazyTimestamps:
         return self._total
 
     @property
-    def ndim(self) -> int:
-        return 1
-
-    @property
     def dtype(self) -> np.dtype:
         return np.dtype("float64")
 
@@ -499,6 +495,10 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 "Timestamps are not strictly increasing. This may cause problems with some software or data analysis.",
                 stacklevel=2,
             )
+        elif isinstance(self.timestamps, _LazyTimestamps):
+            # Strictly increasing implies non-decreasing, so cache it -- this spares
+            # the non-PTP digitize path a second full streamed pass (#47).
+            self.timestamps._non_decreasing = True
 
         self.n_time = [
             neo_io.get_signal_size(
@@ -516,8 +516,8 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         # future change that desynchronises them fails loud here rather than
         # silently writing mismatched-length timestamps.
         if isinstance(self.timestamps, _LazyTimestamps):
-            assert self.timestamps._total == sum(self.n_time), (
-                f"lazy timestamps length {self.timestamps._total} != data length "
+            assert len(self.timestamps) == sum(self.n_time), (
+                f"lazy timestamps length {len(self.timestamps)} != data length "
                 f"{sum(self.n_time)}"
             )
 

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -552,38 +552,34 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             )
         channel_ids = [str(x) for x in self.nwb_hw_channel_order[selection_list[1]]]
         # what global index each file starts at
-        file_start_ind = np.append(np.zeros(1), np.cumsum(self.n_time))
-        # the time indexes we want
-        time_index = np.arange(selection_list[0].start, selection_list[0].stop)[
-            :: selection_list[0].step
-        ]
+        file_start_ind = np.append(np.zeros(1, dtype=np.int64), np.cumsum(self.n_time))
+        max_time, max_channel = self._get_maxshape()
+        time_start, time_stop, _ = selection_list[0].indices(max_time)
+        if time_stop <= time_start:
+            selected_channels = np.arange(max_channel)[selection[1]]
+            return np.empty((0, len(selected_channels)), dtype=np.int16)
         data = []
-        i = time_index[0]
-        while i < min(time_index[-1], self._get_maxshape()[0]):
+        i = time_start
+        while i < time_stop:
             # find the stream where this piece of slice begins
-            io_stream = np.argmin(i >= file_start_ind) - 1
+            io_stream = np.searchsorted(file_start_ind, i, side="right") - 1
+            local_start = i - file_start_ind[io_stream]
+            local_stop = min(
+                time_stop - file_start_ind[io_stream],
+                self.n_time[io_stream],
+            )
             # get the data from that stream
             data.append(
                 self.neo_io[io_stream].get_analogsignal_chunk(
                     block_index=self.block_index,
                     seg_index=self.seg_index,
-                    i_start=int(i - file_start_ind[io_stream]),
-                    i_stop=int(
-                        min(
-                            time_index[-1] - file_start_ind[io_stream],
-                            self.n_time[io_stream],
-                        )
-                    )
-                    + 1,
+                    i_start=int(local_start),
+                    i_stop=int(local_stop),
                     stream_index=self.stream_index,
                     channel_ids=channel_ids,
                 )
             )
-            i += min(
-                self.n_time[io_stream]
-                - (i - file_start_ind[io_stream]),  # if added up to the end of stream
-                time_index[-1] - i,  # if finished in this stream
-            )
+            i = file_start_ind[io_stream] + local_stop
 
         data = (np.concatenate(data) * self.conversion).astype("int16")
         # Handle the appended multiplex data

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -411,7 +411,10 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         if nwb_hw_channel_order is None:
             nwb_hw_channel_order = []
         if len(nwb_hw_channel_order) == 0:  # TODO: raise error instead?
-            self.nwb_hw_channel_order = np.arange(self.n_channel)
+            signal_channels = self.neo_io[0].header["signal_channels"]
+            self.nwb_hw_channel_order = signal_channels[
+                signal_channels["stream_id"] == self.stream_id
+            ]["id"]
         else:
             self.nwb_hw_channel_order = nwb_hw_channel_order
 
@@ -544,20 +547,21 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         # those are stored in the file as channel IDs
         # make into list form passed to neo_io
         selection_list = list(selection)
-        if self.is_analog:
-            selection_list[1] = slice(
-                selection[1].start,
-                min(selection[1].stop, self.n_channel),
-                selection[1].step,
-            )
-        channel_ids = [str(x) for x in self.nwb_hw_channel_order[selection_list[1]]]
         # what global index each file starts at
         file_start_ind = np.append(np.zeros(1, dtype=np.int64), np.cumsum(self.n_time))
         max_time, max_channel = self._get_maxshape()
+        requested_channels = np.arange(max_channel)[selection[1]]
+        if self.is_analog:
+            analog_channels = requested_channels[requested_channels < self.n_channel]
+            channel_ids = [
+                str(x) for x in np.asarray(self.nwb_hw_channel_order)[analog_channels]
+            ]
+        else:
+            selection_list[1] = selection[1]
+            channel_ids = [str(x) for x in self.nwb_hw_channel_order[selection_list[1]]]
         time_start, time_stop, _ = selection_list[0].indices(max_time)
         if time_stop <= time_start:
-            selected_channels = np.arange(max_channel)[selection[1]]
-            return np.empty((0, len(selected_channels)), dtype=np.int16)
+            return np.empty((0, len(requested_channels)), dtype=np.int16)
         data = []
         i = time_start
         while i < time_stop:
@@ -593,21 +597,20 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 self.n_channel
             )  # number of non-multiplexed channels in the dataset
             n_analog_selected = data.shape[1] - n_multiplex
-            return_indices = np.arange(
-                n_analog_selected
-            )  # include all non-multiplexed channels pulled
-            # determine which multiplex channels are being requested
-            if (
-                selection[1].stop > n_analog
-            ):  # if multiplexed channels are being requested
-                requested_multiplex = np.arange(n_multiplex) + n_analog_selected
-                multiplex_slice = slice(
-                    max(selection[1].start - n_analog, 0),
-                    max(selection[1].stop - n_analog, 0),
-                    selection[1].step,
+            analog_lookup = {
+                int(channel): i
+                for i, channel in enumerate(
+                    requested_channels[requested_channels < n_analog]
                 )
-                requested_multiplex = requested_multiplex[multiplex_slice]
-                return_indices = np.append(return_indices, requested_multiplex)
+            }
+            return_indices = [
+                (
+                    analog_lookup[int(channel)]
+                    if channel < n_analog
+                    else n_analog_selected + int(channel) - n_analog
+                )
+                for channel in requested_channels
+            ]
             data = data[:, return_indices]
 
         return data

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -148,12 +148,15 @@ class _LazyTimestamps:
             parts.append(self._read_file(file_index, lo, hi))
         return parts[0] if len(parts) == 1 else np.concatenate(parts)
 
-    def _gather(self, indices: np.ndarray) -> np.ndarray:
-        """Fancy index: load only the spanned contiguous range, then index into it.
+    def _gather(self, indices: np.ndarray, max_span: int = 1 << 22) -> np.ndarray:
+        """Fancy index without materialising more than ``max_span`` at once.
 
-        Headstage update indices are sparse but confined to a single file, so the
-        spanned range is one file's worth of timestamps (a few MB), never the
-        whole recording.
+        Loads the covered index range in capped contiguous blocks (default
+        ~4M elements = 32 MiB), then selects. Headstage update indices are sparse
+        but can span a whole 30-min split file (~432 MB of timestamps at 30 kHz);
+        blocking keeps the transient bounded while staying byte-identical to the
+        eager array indexed. The common small-span case takes the single-read
+        fast path below.
         """
         indices = np.asarray(indices)
         if indices.dtype == bool:
@@ -169,8 +172,17 @@ class _LazyTimestamps:
             raise IndexError(
                 f"fancy index out of bounds [{lo}, {hi}] for length {self._total}"
             )
-        block = self._slice(lo, hi + 1)
-        return block[indices - lo]
+        if hi - lo + 1 <= max_span:
+            block = self._slice(lo, hi + 1)
+            return block[indices - lo]
+        out = np.empty(indices.shape, dtype=np.float64)
+        for block_lo in range(lo, hi + 1, max_span):
+            block_hi = min(block_lo + max_span, hi + 1)
+            in_block = (indices >= block_lo) & (indices < block_hi)
+            if in_block.any():
+                block = self._slice(block_lo, block_hi)
+                out[in_block] = block[indices[in_block] - block_lo]
+        return out
 
     def __getitem__(self, key):
         if isinstance(key, slice):

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -66,24 +66,27 @@ class _LazyTimestamps:
 
     Values are **byte-identical** to the old concatenation: every timestamp is
     ``intercept + slope * unwrapped_counter`` (sysClock path) or
-    ``(counter - counter0) / rate + t_creation`` (fallback). Both are elementwise
-    and independent of how the array is chunked, and ``get_regressed_systime`` /
-    ``get_systime_from_trodes_timestamps`` already support arbitrary sub-ranges
-    (including across uint32 wraps) and cache the fit, so a per-file sub-range
-    read returns exactly the same bytes as the whole-file read sliced.
+    ``(counter - counter0) / rate + t_creation`` (fallback). The computation is
+    **chunk-independent** -- any sub-range read equals the whole-file read sliced,
+    including across uint32 wraps (``get_regressed_systime`` restores the wrap
+    offset per slice via ``prior_wraps``). Both readers reuse the cached
+    regression *parameters* (``regressed_systime_parameters``), so a per-file
+    sub-range read is cheap. (Note: those readers are also ``lru_cache(maxsize=1)``
+    on the full returned array, so a one-off ``(0, None)`` call would retain a
+    whole-file array -- the lazy path here never makes that call.)
 
     Supported access -- one per consumer of ``RecFileDataChunkIterator.timestamps``:
 
     - ``ts[a:b]``        contiguous slice  -> chunked writes; the monotonicity scan
     - ``ts[int_array]``  integer fancy index -> decimated headstage sensor timestamps
     - ``ts[i]``          scalar
-    - ``np.asarray(ts)`` full materialise -> ``np.digitize`` / ``np.concatenate``
-      (the non-PTP position path; step 3 removes that last full materialisation)
+    - ``np.asarray(ts)`` full materialise -> generic NumPy fallback only; after
+      step 3 no hot path uses it (the non-PTP position path now indexes lazily)
 
     For chunk-by-chunk HDF5 writes use :meth:`as_data_chunk_iterator` (a
-    ``GenericDataChunkIterator``); pynwb writes a plain array via ``data[:]`` in
-    one shot (which would call ``__array__`` and re-materialise the whole array),
-    but streams an ``AbstractDataChunkIterator``.
+    ``GenericDataChunkIterator``). pynwb materialises a plain array-like in one
+    shot via ``data[:]`` (calling ``__array__``); it writes only an
+    ``AbstractDataChunkIterator`` iteratively -- hence that wrapper.
     """
 
     def __init__(self, neo_io: list, use_sysclock: bool):
@@ -162,6 +165,10 @@ class _LazyTimestamps:
             indices = np.where(indices < 0, indices + self._total, indices)
         lo = int(indices.min())
         hi = int(indices.max())
+        if lo < 0 or hi >= self._total:
+            raise IndexError(
+                f"fancy index out of bounds [{lo}, {hi}] for length {self._total}"
+            )
         block = self._slice(lo, hi + 1)
         return block[indices - lo]
 
@@ -184,7 +191,21 @@ class _LazyTimestamps:
         # integer (or boolean) array fancy indexing
         return self._gather(key)
 
+    def __iter__(self):
+        # Without this, Python's sequence-protocol fallback (via __getitem__)
+        # would iterate element-by-element, each a separate on-disk read -- a
+        # silent O(n) trap. Force callers to materialise explicitly instead.
+        raise TypeError(
+            "refusing to iterate _LazyTimestamps lazily (each step is a separate "
+            "disk read); use np.asarray(ts) or ts.as_data_chunk_iterator()"
+        )
+
     def __array__(self, dtype=None, copy=None) -> np.ndarray:
+        # A virtual array can only ever produce a freshly-built array, so an
+        # explicit copy=False ("give me a no-copy view") is unsatisfiable; match
+        # NumPy 2's contract and refuse loudly rather than silently copying.
+        if copy is False:
+            raise ValueError("cannot return a no-copy view of a lazy virtual array")
         out = self._slice(0, self._total)
         if dtype is not None:
             out = out.astype(dtype, copy=False)
@@ -441,6 +462,18 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             )
             for neo_io in self.neo_io
         ]
+
+        # The lazy timestamps and the data must describe the same number of
+        # samples. Both ultimately read each file's post-interpolation packet
+        # count (_LazyTimestamps via _raw_memmap.shape[0], n_time via
+        # get_signal_size), so this holds by construction -- assert it so a
+        # future change that desynchronises them fails loud here rather than
+        # silently writing mismatched-length timestamps.
+        if isinstance(self.timestamps, _LazyTimestamps):
+            assert self.timestamps._total == sum(self.n_time), (
+                f"lazy timestamps length {self.timestamps._total} != data length "
+                f"{sum(self.n_time)}"
+            )
 
         super().__init__(**kwargs)
 

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -33,6 +33,27 @@ DEFAULT_CHUNK_TIME_DIM = 16384
 DEFAULT_CHUNK_MAX_CHANNEL_DIM = 32
 
 
+def _is_strictly_increasing(values, chunk_size: int = 1_000_000) -> bool:
+    """Return whether ``values`` is strictly increasing, streaming in chunks.
+
+    Equivalent to ``np.all(np.diff(values) > 0)`` but never allocates the full
+    diff array -- for the ~15 GB timestamp array at 17 h that diff would double
+    peak memory (#47). Reads at most ``chunk_size`` elements at a time and checks
+    the within-chunk diffs plus each chunk boundary, returning early on the first
+    non-increase.
+    """
+    n = len(values)
+    if n < 2:
+        return True
+    previous = values[0]
+    for start in range(1, n, chunk_size):
+        block = np.asarray(values[start : start + chunk_size])
+        if block[0] <= previous or not np.all(np.diff(block) > 0):
+            return False
+        previous = block[-1]
+    return True
+
+
 class RecFileDataChunkIterator(GenericDataChunkIterator):
     """Data chunk iterator for SpikeGadgets rec files."""
 
@@ -216,10 +237,14 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             )
 
         logger.info("Reading timestamps COMPLETE")
-        is_timestamps_sequential = np.all(np.diff(self.timestamps))
+        # Must be strictly increasing. `np.all(np.diff(...))` only checks that no
+        # two timestamps are *equal* (nonzero diff); it silently accepts a
+        # backward jump (negative diff), which is exactly what a clock reset or
+        # an out-of-order file concatenation would produce.
+        is_timestamps_sequential = _is_strictly_increasing(self.timestamps)
         if not is_timestamps_sequential:
             warn(
-                "Timestamps are not sequential. This may cause problems with some software or data analysis.",
+                "Timestamps are not strictly increasing. This may cause problems with some software or data analysis.",
                 stacklevel=2,
             )
 

--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -40,7 +40,7 @@ class _TrodesSampleCountIterator(GenericDataChunkIterator):
 
     def _get_data(self, selection: tuple) -> np.ndarray:
         start, stop, _ = selection[0].indices(self._total)
-        out = np.empty(stop - start, dtype=np.uint32)
+        out = np.empty(max(0, stop - start), dtype=np.uint32)
         for i, io in enumerate(self._neo_io):
             file_start = int(self._file_starts[i])
             file_stop = int(self._file_starts[i + 1])
@@ -67,6 +67,11 @@ class _TrodesSampleCountIterator(GenericDataChunkIterator):
 
     def __getitem__(self, key):
         if isinstance(key, slice):
+            if key.step not in (None, 1):
+                raise ValueError(
+                    f"{type(self).__name__} does not support a step in slices; "
+                    f"got step={key.step}"
+                )
             return self._get_data((key,))
         if isinstance(key, (int, np.integer)):
             i = int(key)

--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -90,8 +90,10 @@ def add_sample_count(
         description="corespondence between sample count and timestamps",
     )
 
-    # get the systime information
-    systime = np.array(rec_dci.timestamps)
+    # Reference the already-resident ephys timestamps directly rather than
+    # copying them -- the copy duplicated the whole array (~15 GB at 17 h). This
+    # matches how add_analog/add_raw_ephys already reuse rec_dci.timestamps (#47).
+    systime = rec_dci.timestamps
     # get the sample count information
     trodes_sample = np.concatenate(
         [neo_io.get_analogsignal_timestamps(0, None) for neo_io in rec_dci.neo_io]

--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -9,7 +9,10 @@ import pandas as pd
 from hdmf.data_utils import GenericDataChunkIterator
 from pynwb import NWBFile, TimeSeries
 
-from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.convert_ephys import (
+    RecFileDataChunkIterator,
+    _timestamps_for_write,
+)
 from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 
 MILLISECONDS_PER_SECOND = 1e3
@@ -130,10 +133,12 @@ def add_sample_count(
         description="corespondence between sample count and timestamps",
     )
 
-    # Reference the already-resident ephys timestamps directly rather than
-    # copying them -- the copy duplicated the whole array (~15 GB at 17 h). This
-    # matches how add_analog/add_raw_ephys already reuse rec_dci.timestamps (#47).
-    systime = rec_dci.timestamps
+    # Reference the already-lazy ephys timestamps directly rather than copying
+    # them -- the copy duplicated the whole array (~15 GB at 17 h). Wrap them in a
+    # DataChunkIterator so the dataset is streamed to disk chunk-by-chunk instead
+    # of re-materialising on write (#47), matching how add_raw_ephys / add_analog
+    # now stream their timestamps too.
+    systime = _timestamps_for_write(rec_dci.timestamps)
     # Stream the sample counts instead of concatenating every file's into one
     # array (~7 GB at 17 h); they are written chunk-by-chunk from the memmaps.
     trodes_sample = _TrodesSampleCountIterator(rec_dci.neo_io)

--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -57,6 +57,29 @@ class _TrodesSampleCountIterator(GenericDataChunkIterator):
     def _get_dtype(self) -> np.dtype:
         return np.dtype("uint32")
 
+    # Read-access surface so consumers can slice the streamed counts directly
+    # (e.g. the non-PTP position path takes a single epoch's sample counts,
+    # ``sample_count[epoch_start:epoch_stop]``). Without this a bare
+    # GenericDataChunkIterator is not subscriptable. Values match
+    # ``np.concatenate([io.get_analogsignal_timestamps(0, None) for io in neo_io])``.
+    def __len__(self) -> int:
+        return self._total
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            return self._get_data((key,))
+        if isinstance(key, (int, np.integer)):
+            i = int(key)
+            if i < 0:
+                i += self._total
+            if not 0 <= i < self._total:
+                raise IndexError(f"index {key} out of range for length {self._total}")
+            return self._get_data((slice(i, i + 1),))[0]
+        raise TypeError(
+            f"{type(self).__name__} indices must be int or slice, not "
+            f"{type(key).__name__}"
+        )
+
 
 def add_epochs(
     nwbfile: NWBFile,

--- a/src/trodes_to_nwb/convert_intervals.py
+++ b/src/trodes_to_nwb/convert_intervals.py
@@ -6,6 +6,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from hdmf.data_utils import GenericDataChunkIterator
 from pynwb import NWBFile, TimeSeries
 
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
@@ -13,6 +14,45 @@ from trodes_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
 
 MILLISECONDS_PER_SECOND = 1e3
 NANOSECONDS_PER_SECOND = 1e9
+
+
+class _TrodesSampleCountIterator(GenericDataChunkIterator):
+    """Stream the Trodes sample counts as one virtual 1-D ``uint32`` array.
+
+    The sample-count data spans every rec file in the session. Concatenating all
+    of them up front materialises the whole array (~7 GB at 17 h @30 kHz); this
+    iterator instead reads each requested chunk on demand from the files'
+    memmaps, so the counts are never all resident at once (issue #47). The values
+    and their order are identical to
+    ``np.concatenate([io.get_analogsignal_timestamps(0, None) for io in neo_io])``.
+    """
+
+    def __init__(self, neo_io: list[SpikeGadgetsRawIO], **kwargs):
+        self._neo_io = list(neo_io)
+        lengths = [io._raw_memmap.shape[0] for io in self._neo_io]
+        # global index of the first sample of each file (plus a final total)
+        self._file_starts = np.concatenate([[0], np.cumsum(lengths)]).astype(np.int64)
+        self._total = int(self._file_starts[-1])
+        super().__init__(**kwargs)
+
+    def _get_data(self, selection: tuple) -> np.ndarray:
+        start, stop, _ = selection[0].indices(self._total)
+        out = np.empty(stop - start, dtype=np.uint32)
+        for i, io in enumerate(self._neo_io):
+            file_start = int(self._file_starts[i])
+            file_stop = int(self._file_starts[i + 1])
+            lo, hi = max(start, file_start), min(stop, file_stop)
+            if lo < hi:
+                out[lo - start : hi - start] = io.get_analogsignal_timestamps(
+                    lo - file_start, hi - file_start
+                )
+        return out
+
+    def _get_maxshape(self) -> tuple:
+        return (self._total,)
+
+    def _get_dtype(self) -> np.dtype:
+        return np.dtype("uint32")
 
 
 def add_epochs(
@@ -94,10 +134,9 @@ def add_sample_count(
     # copying them -- the copy duplicated the whole array (~15 GB at 17 h). This
     # matches how add_analog/add_raw_ephys already reuse rec_dci.timestamps (#47).
     systime = rec_dci.timestamps
-    # get the sample count information
-    trodes_sample = np.concatenate(
-        [neo_io.get_analogsignal_timestamps(0, None) for neo_io in rec_dci.neo_io]
-    )
+    # Stream the sample counts instead of concatenating every file's into one
+    # array (~7 GB at 17 h); they are written chunk-by-chunk from the memmaps.
+    trodes_sample = _TrodesSampleCountIterator(rec_dci.neo_io)
 
     # insert into nwbfile
     nwbfile.processing["sample_count"].add(

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -765,6 +765,16 @@ def _get_position_timestamps_no_ptp(
     # materialising the whole ~14.7 GB-at-17h array (np.digitize would).
     epoch_start_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[0])
     epoch_end_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[1])
+    # epoch_interval[0] <= epoch_interval[1], so for monotonically-increasing
+    # timestamps start <= end. The lazy binary search in _scalar_digitize assumes
+    # that monotonicity (only warned about at iterator build, not enforced); a
+    # start past the end means it was violated, so fail loud rather than slice a
+    # meaningless backwards window.
+    if epoch_start_ind > epoch_end_ind:
+        raise ValueError(
+            f"non-PTP epoch start index {epoch_start_ind} exceeds end index "
+            f"{epoch_end_ind}; rec timestamps are not monotonically increasing"
+        )
     is_valid_camera_time = np.isin(
         video_timestamps.index, sample_count[epoch_start_ind:epoch_end_ind]
     )

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -83,6 +83,29 @@ def wrapped_digitize(
     return ind_first * (1 - section) + ind_second * section
 
 
+def _scalar_digitize(timestamps, value: float) -> int:
+    """``int(np.digitize(value, timestamps))`` without materialising ``timestamps``.
+
+    For monotonically increasing ``timestamps`` (the rec timestamps are strictly
+    increasing), ``np.digitize(value, ts)`` equals ``np.searchsorted(ts, value,
+    side="right")`` -- the count of timestamps ``<= value``. Used to locate the
+    two scalar epoch-boundary indices in the non-PTP position path. For a plain
+    array this defers to ``np.searchsorted``; for the lazy virtual timestamps
+    (#47) it is an O(log n) binary search using only scalar reads, so the full
+    ~14.7 GB-at-17h array is never materialised just to find two boundaries.
+    """
+    if isinstance(timestamps, np.ndarray):
+        return int(np.searchsorted(timestamps, value, side="right"))
+    low, high = 0, len(timestamps)
+    while low < high:
+        mid = (low + high) // 2
+        if timestamps[mid] <= value:
+            low = mid + 1
+        else:
+            high = mid
+    return low
+
+
 def parse_dtype(fieldstr: str) -> np.dtype:
     """
     Parses the last fields parameter (<time uint32><...>) as a single string.
@@ -728,8 +751,11 @@ def _get_position_timestamps_no_ptp(
 
     frame_count = np.asarray(video_timestamps.HWframeCount)
 
-    epoch_start_ind = np.digitize(epoch_interval[0], rec_dci_timestamps)
-    epoch_end_ind = np.digitize(epoch_interval[1], rec_dci_timestamps)
+    # Locate the epoch's sample-index bounds. ``rec_dci_timestamps`` is the lazy
+    # virtual timestamps (#47); searching it for the two scalar boundaries avoids
+    # materialising the whole ~14.7 GB-at-17h array (np.digitize would).
+    epoch_start_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[0])
+    epoch_end_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[1])
     is_valid_camera_time = np.isin(
         video_timestamps.index, sample_count[epoch_start_ind:epoch_end_ind]
     )

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -99,12 +99,21 @@ def _scalar_digitize(timestamps, value: float) -> int:
       ``np.digitize`` equals ``np.searchsorted(ts, value, side="right")`` (the
       count of timestamps ``<= value``), computed here as an O(log n) binary
       search using only scalar reads, so the full ~14.7 GB-at-17h array is never
-      materialised just to find two boundaries. The binary search assumes the
-      monotonicity precondition above; unlike ``np.digitize`` it does not
-      re-scan to verify it (that would defeat the point of staying lazy).
+      materialised just to find two boundaries. To preserve ``np.digitize``'s
+      fail-loud contract, a lazy object exposing ``is_non_decreasing()`` is first
+      checked for an actual backward jump (a clock reset) and raises if found --
+      duplicates still pass (``np.digitize`` allows them); only decreases raise.
     """
     if isinstance(timestamps, np.ndarray):
         return int(np.digitize(value, timestamps))
+    # The binary search assumes monotonic bins. np.digitize would raise on a
+    # decreasing array; match that here (cheap, streamed, cached) so a clock
+    # reset fails loud instead of returning a plausible-but-wrong index.
+    if hasattr(timestamps, "is_non_decreasing") and not timestamps.is_non_decreasing():
+        raise ValueError(
+            "timestamps decrease somewhere (a clock reset?); cannot compute a "
+            "digitize index -- np.digitize requires monotonic bins"
+        )
     low, high = 0, len(timestamps)
     while low < high:
         mid = (low + high) // 2
@@ -763,18 +772,10 @@ def _get_position_timestamps_no_ptp(
     # Locate the epoch's sample-index bounds. ``rec_dci_timestamps`` is the lazy
     # virtual timestamps (#47); searching it for the two scalar boundaries avoids
     # materialising the whole ~14.7 GB-at-17h array (np.digitize would).
+    # _scalar_digitize raises on a decreasing array (a clock reset), matching
+    # np.digitize's fail-loud, so the bounds here are well-defined and ordered.
     epoch_start_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[0])
     epoch_end_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[1])
-    # epoch_interval[0] <= epoch_interval[1], so for monotonically-increasing
-    # timestamps start <= end. The lazy binary search in _scalar_digitize assumes
-    # that monotonicity (only warned about at iterator build, not enforced); a
-    # start past the end means it was violated, so fail loud rather than slice a
-    # meaningless backwards window.
-    if epoch_start_ind > epoch_end_ind:
-        raise ValueError(
-            f"non-PTP epoch start index {epoch_start_ind} exceeds end index "
-            f"{epoch_end_ind}; rec timestamps are not monotonically increasing"
-        )
     is_valid_camera_time = np.isin(
         video_timestamps.index, sample_count[epoch_start_ind:epoch_end_ind]
     )

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -86,16 +86,25 @@ def wrapped_digitize(
 def _scalar_digitize(timestamps, value: float) -> int:
     """``int(np.digitize(value, timestamps))`` without materialising ``timestamps``.
 
-    For monotonically increasing ``timestamps`` (the rec timestamps are strictly
-    increasing), ``np.digitize(value, ts)`` equals ``np.searchsorted(ts, value,
-    side="right")`` -- the count of timestamps ``<= value``. Used to locate the
-    two scalar epoch-boundary indices in the non-PTP position path. For a plain
-    array this defers to ``np.searchsorted``; for the lazy virtual timestamps
-    (#47) it is an O(log n) binary search using only scalar reads, so the full
-    ~14.7 GB-at-17h array is never materialised just to find two boundaries.
+    Used to locate the two scalar epoch-boundary indices in the non-PTP position
+    path. ``timestamps`` is required to be monotonically increasing -- the same
+    precondition the surrounding non-PTP code already assumes, and which is
+    checked over the whole array when the iterator is built (a warning; see
+    ``_is_strictly_increasing`` in ``convert_ephys``).
+
+    - **Plain ``np.ndarray``** (e.g. timestamps read back from a file): defers to
+      ``np.digitize`` directly, so behaviour -- including the ``ValueError`` it
+      raises on a non-monotonic array -- is unchanged.
+    - **Lazy virtual timestamps** (#47): for monotonically increasing bins
+      ``np.digitize`` equals ``np.searchsorted(ts, value, side="right")`` (the
+      count of timestamps ``<= value``), computed here as an O(log n) binary
+      search using only scalar reads, so the full ~14.7 GB-at-17h array is never
+      materialised just to find two boundaries. The binary search assumes the
+      monotonicity precondition above; unlike ``np.digitize`` it does not
+      re-scan to verify it (that would defeat the point of staying lazy).
     """
     if isinstance(timestamps, np.ndarray):
-        return int(np.searchsorted(timestamps, value, side="right"))
+        return int(np.digitize(value, timestamps))
     low, high = 0, len(timestamps)
     while low < high:
         mid = (low + high) // 2

--- a/src/trodes_to_nwb/convert_position.py
+++ b/src/trodes_to_nwb/convert_position.py
@@ -776,14 +776,15 @@ def _get_position_timestamps_no_ptp(
     # np.digitize's fail-loud, so the bounds here are well-defined and ordered.
     epoch_start_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[0])
     epoch_end_ind = _scalar_digitize(rec_dci_timestamps, epoch_interval[1])
-    is_valid_camera_time = np.isin(
-        video_timestamps.index, sample_count[epoch_start_ind:epoch_end_ind]
-    )
+    # Read this epoch's sample counts once -- sample_count may be a streamed
+    # iterator where each slice is a fresh memmap read (#47).
+    epoch_sample_count = sample_count[epoch_start_ind:epoch_end_ind]
+    is_valid_camera_time = np.isin(video_timestamps.index, epoch_sample_count)
 
     camera_systime = rec_dci_timestamps[
         wrapped_digitize(
             video_timestamps.index[is_valid_camera_time],
-            sample_count[epoch_start_ind:epoch_end_ind],
+            epoch_sample_count,
         )
         + epoch_start_ind
     ]

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -57,6 +57,27 @@ def _unwrap_uint32(values: np.ndarray) -> np.ndarray:
     return unwrapped + offsets
 
 
+def _find_single_dropped_packet_indices(
+    raw_memmap: np.ndarray,
+    timestamp_byte: int,
+    start_index: int = 0,
+    stop_index: int | None = None,
+) -> np.ndarray:
+    """Return pre-interpolation indices whose next packet skips one sample."""
+    if stop_index is None:
+        stop_index = raw_memmap.shape[0]
+    if stop_index - start_index < 2:
+        return np.empty(0, dtype=np.int64)
+    raw_uint8 = raw_memmap[
+        start_index:stop_index,
+        timestamp_byte : timestamp_byte + TIMESTAMP_SIZE_BYTES,
+    ]
+    raw_uint32 = raw_uint8.view("uint8").reshape(-1, 4).view("uint32").reshape(-1)
+    return (
+        np.where(np.diff(raw_uint32) == EXPECTED_TIMESTAMP_DIFF_DROP)[0] + start_index
+    )
+
+
 def _fit_systime_regression_streaming(
     read_counter,
     read_sysclock,
@@ -807,17 +828,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
         if self.interpolate_dropped_packets and self.interpolate_index is None:
             # first call in a interpolation iterator, needs to find the dropped packets
             # has to run through the entire file to find missing packets
-            raw_uint8 = self._raw_memmap[
-                :, self._timestamp_byte : self._timestamp_byte + TIMESTAMP_SIZE_BYTES
-            ]
-            raw_uint32 = (
-                raw_uint8.view("uint8").reshape(-1, 4).view("uint32").reshape(-1)
+            self.interpolate_index = _find_single_dropped_packet_indices(
+                self._raw_memmap, self._timestamp_byte
             )
-            self.interpolate_index = np.where(
-                np.diff(raw_uint32) == EXPECTED_TIMESTAMP_DIFF_DROP
-            )[
-                0
-            ]  # find locations of single dropped packets
             self._interpolate_raw_memmap()  # interpolates in the memmap
 
         # subsequent calls in a interpolation iterator don't remake the interpolated memmap, start here
@@ -1440,23 +1453,32 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
                 )
         # Inherit the original memmap object from the full_io object to conserve virtual memory
         if isinstance(full_io._raw_memmap, InsertedMemmap):
-            self._raw_memmap = full_io._raw_memmap._raw_memmap
+            full_raw_memmap = full_io._raw_memmap._raw_memmap
         else:
-            self._raw_memmap = full_io._raw_memmap
-        self._raw_memmap = self._raw_memmap[start_index:stop_index]
+            full_raw_memmap = full_io._raw_memmap
+        self._raw_memmap = full_raw_memmap[start_index:stop_index]
         # ensure interpolation
         if self.interpolate_dropped_packets and self.interpolate_index is None:
-            raw_uint8 = self._raw_memmap[
-                :, self._timestamp_byte : self._timestamp_byte + TIMESTAMP_SIZE_BYTES
-            ]
-            raw_uint32 = (
-                raw_uint8.view("uint8").reshape(-1, 4).view("uint32").reshape(-1)
+            if isinstance(full_io._raw_memmap, InsertedMemmap) and (
+                full_io.interpolate_index is not None
+            ):
+                inserted_index = np.asarray(full_io.interpolate_index, dtype=np.int64)
+            else:
+                # Scan one packet past the partial stop so a dropped packet whose
+                # diff straddles the split is still inserted into this partial.
+                scan_stop = min(stop_index + 1, full_raw_memmap.shape[0])
+                inserted_index = _find_single_dropped_packet_indices(
+                    full_raw_memmap,
+                    self._timestamp_byte,
+                    start_index=start_index,
+                    stop_index=scan_stop,
+                )
+            self.interpolate_index = (
+                inserted_index[
+                    (inserted_index >= start_index) & (inserted_index < stop_index)
+                ]
+                - start_index
             )
-            self.interpolate_index = np.where(
-                np.diff(raw_uint32) == EXPECTED_TIMESTAMP_DIFF_DROP
-            )[
-                0
-            ]  # find locations of single dropped packets
             self._interpolate_raw_memmap()
 
     @functools.lru_cache(maxsize=2)

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -1155,6 +1155,16 @@ class SpikeGadgetsRawIO(BaseRawIO):
         # arrays (#47). Partial (split) iterators inherit these parameters and so
         # skip the fit (see SpikeGadgetsRawIOPartial).
         if not self.regressed_systime_parameters:
+            # Resolve dropped-packet interpolation first so n_total reflects the
+            # final (post-interpolation) length. Otherwise the first counter read
+            # inside the fit expands _raw_memmap mid-fit and the streaming loop
+            # stops short of the inserted tail (a wrap there would be missed). On
+            # the non-split path the iterator already resolves this; this guards
+            # the split path, which fits here before that happens (#47).
+            if getattr(self, "interpolate_dropped_packets", False) and (
+                getattr(self, "interpolate_index", None) is None
+            ):
+                self.get_analogsignal_timestamps(0, 1)
             slope, intercept, wrap_sample_indices = _fit_systime_regression_streaming(
                 self.get_analogsignal_timestamps,
                 self.get_sys_clock,

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -25,8 +25,20 @@ BITS_PER_BYTE = 8
 TIMESTAMP_SIZE_BYTES = 4  # uint32
 SYSCLOCK_SIZE_BYTES = 8  # int64
 EPHYS_SAMPLE_SIZE_BYTES = 2  # int16
-EXPECTED_TIMESTAMP_DIFF_DROP = 2  # Indicates a single dropped packet
-UINT32_WRAP = 2**32  # Trodes timestamp is a uint32 sample counter; it wraps here
+# A single dropped packet leaves a one-sample gap in the uint32 sample counter,
+# i.e. a diff of 2. (Confirmed against Trodes acquisition: it reports
+# `dropped = currentTimeStamp - lastTimeStamp - 1`, so one drop == diff 2.)
+# NOTE: only single drops are interpolated. Multi-packet drops (diff > 2, which
+# Trodes tracks as `largestPacketDrop`) are left as gaps -- timestamps stay
+# correct (the regression maps the actual counter to time), but the ephys data
+# is not padded across the gap.
+EXPECTED_TIMESTAMP_DIFF_DROP = 2
+# The Trodes per-packet timestamp is a uint32 hardware sample counter
+# (abstractTrodesSource.h: "hardware timestamps (sample number)") that wraps here
+# (~39.77 h at 30 kHz). A wrap is a large backward jump in the .rec; _unwrap_uint32
+# only unwraps jumps < -2**31, distinguishing a clean wrap (~-2**32) from minor
+# corruption (which Trodes discards at acquisition).
+UINT32_WRAP = 2**32
 
 
 def _unwrap_uint32(values: np.ndarray) -> np.ndarray:

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -27,6 +27,35 @@ TIMESTAMP_SIZE_BYTES = 4  # uint32
 SYSCLOCK_SIZE_BYTES = 8  # int64
 EPHYS_SAMPLE_SIZE_BYTES = 2  # int16
 EXPECTED_TIMESTAMP_DIFF_DROP = 2  # Indicates a single dropped packet
+UINT32_WRAP = 2**32  # Trodes timestamp is a uint32 sample counter; it wraps here
+
+
+def _unwrap_uint32(values: np.ndarray) -> np.ndarray:
+    """Unwrap a monotonically increasing uint32 counter that may have wrapped.
+
+    The Trodes per-packet timestamp is a uint32 sample counter that rolls over
+    after ``2**32`` samples (~39.77 h at 30 kHz). A rollover appears as a large
+    negative jump once the values are viewed as signed integers. This adds
+    ``2**32`` at and after each detected wrap and returns ``int64`` values that
+    are globally monotonic relative to ``values[0]``.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        1D array of uint32 timestamp counter values.
+
+    Returns
+    -------
+    np.ndarray
+        ``int64`` array of the same shape, unwrapped.
+    """
+    unwrapped = np.asarray(values, dtype=np.int64)
+    if unwrapped.size < 2:
+        return unwrapped
+    wraps = np.diff(unwrapped) < -(UINT32_WRAP // 2)
+    offsets = np.zeros(unwrapped.size, dtype=np.int64)
+    offsets[1:] = np.cumsum(wraps) * UINT32_WRAP
+    return unwrapped + offsets
 
 
 class SpikeGadgetsRawIO(BaseRawIO):
@@ -494,6 +523,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         # initialize systime parameters as empty dict so can check if they have been set in a get_regressed_systime call
         self.regressed_systime_parameters = {}
+        # offset of this object's first sample within the full recording; 0 for a
+        # full file, set to start_index for partial iterators. Used to anchor the
+        # uint32 timestamp unwrap to a single global axis (see get_regressed_systime).
+        self._global_sample_offset = 0
 
         self._generate_minimal_annotations()
         # info from GlobalConfiguration in xml are copied to block and seg annotations
@@ -998,11 +1031,27 @@ class SpikeGadgetsRawIO(BaseRawIO):
             A NumPy array containing the adjusted system timestamps.
         """
         NANOSECONDS_PER_SECOND = 1e9
-        # get trodes timestamp values
-        trodestime = self.get_analogsignal_timestamps(i_start, i_stop)
-        # Convert
-        trodestime_index = np.asarray(trodestime, dtype=np.float64)
+        # Get the raw uint32 Trodes timestamps for this slice. The counter wraps
+        # every 2**32 samples (~39.77 h at 30 kHz); unwrap to a globally
+        # monotonic axis anchored at the full recording's sample 0 so that split
+        # (partial) iterators -- which inherit the fitted slope/intercept and may
+        # read a post-wrap sub-range -- land on the same axis (see #169).
+        trodestime = np.asarray(self.get_analogsignal_timestamps(i_start, i_stop))
+        global_start = int(getattr(self, "_global_sample_offset", 0)) + int(
+            i_start or 0
+        )
         if not self.regressed_systime_parameters:
+            # Fitting call (the full recording, in the normal pipeline). Unwrap
+            # this slice and record the global sample index of every wrap so
+            # partial iterators can reconstruct the identical axis.
+            trodestime_index = _unwrap_uint32(trodestime).astype(np.float64)
+            wrap_sample_indices = (
+                np.flatnonzero(
+                    np.diff(trodestime.astype(np.int64)) < -(UINT32_WRAP // 2)
+                )
+                + 1
+                + global_start
+            )
             # get raw systime values
             systime_seconds = self.get_sys_clock(i_start, i_stop)
             # regress
@@ -1010,10 +1059,22 @@ class SpikeGadgetsRawIO(BaseRawIO):
             self.regressed_systime_parameters = {
                 "slope": slope,
                 "intercept": intercept,
+                "wrap_sample_indices": wrap_sample_indices,
             }
         else:
             slope = self.regressed_systime_parameters["slope"]
             intercept = self.regressed_systime_parameters["intercept"]
+            wrap_sample_indices = self.regressed_systime_parameters.get(
+                "wrap_sample_indices", np.empty(0, dtype=np.int64)
+            )
+            # number of wraps before this slice's first global sample, plus any
+            # wrap occurring within the slice, recovers the global axis.
+            prior_wraps = int(
+                np.searchsorted(wrap_sample_indices, global_start, side="right")
+            )
+            trodestime_index = (
+                _unwrap_uint32(trodestime) + prior_wraps * UINT32_WRAP
+            ).astype(np.float64)
         adjusted_timestamps = intercept + slope * trodestime_index
         return (adjusted_timestamps) / NANOSECONDS_PER_SECOND
 
@@ -1224,6 +1285,9 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         self.selected_streams = full_io.selected_streams
         self._generate_minimal_annotations()
         self.regressed_systime_parameters = full_io.regressed_systime_parameters
+        # this partial starts at start_index within the full recording; anchor
+        # the timestamp unwrap to the same global axis as the full-file fit.
+        self._global_sample_offset = start_index
 
         # crop key information to range of interest
         header_size = None

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -1326,42 +1326,23 @@ class InsertedMemmap:
             return self.mapped_index[index]
         # if slice object
         elif isinstance(index, slice):
+            if index.step not in (None, 1):
+                return self.mapped_index[index]
+            start, stop, step = index.indices(self.shape[0])
             # see if slice contains inserted values
-            if (
-                (
-                    (index.start is not None)
-                    and (index.stop is not None)
-                    and np.any(
-                        (self.inserted_locations >= index.start)
-                        & (self.inserted_locations < index.stop)
-                    )
-                )
-                | (
-                    (index.start is None)
-                    and (index.stop is not None)
-                    and np.any(self.inserted_locations < index.stop)
-                )
-                | (
-                    index.stop is None
-                    and (index.start is not None)
-                    and np.any(self.inserted_locations > index.start)
-                )
-                | (
-                    index.start is None
-                    and index.stop is None
-                    and len(self.inserted_locations) > 0
-                )
+            if np.any(
+                (self.inserted_locations >= start) & (self.inserted_locations < stop)
             ):
                 # if so, need to use advanced indexing. return list of indeces
                 return self.mapped_index[index]
             # if not, return slice object with coordinates adjusted
             else:
+                # ``stop`` is exclusive, so an insertion exactly at ``stop`` is
+                # not part of the requested slice and must not shorten it.
                 return slice(
-                    index.start
-                    - np.searchsorted(self.inserted_locations, index.start, "right"),
-                    index.stop
-                    - np.searchsorted(self.inserted_locations, index.stop, "right"),
-                    index.step,
+                    start - np.searchsorted(self.inserted_locations, start, "left"),
+                    stop - np.searchsorted(self.inserted_locations, stop, "left"),
+                    step,
                 )
         # if list of indeces
         else:

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -9,6 +9,7 @@ Intended as a temporary solution until official support is available in Neo.
 # see https://github.com/NeuralEnsemble/python-neo/pull/1303
 
 import functools
+from warnings import warn
 from xml.etree import ElementTree
 
 import numpy as np
@@ -74,8 +75,18 @@ def _find_single_dropped_packet_indices(
     timestamp_byte: int,
     start_index: int = 0,
     stop_index: int | None = None,
+    source: str | None = None,
 ) -> np.ndarray:
-    """Return pre-interpolation indices whose next packet skips one sample."""
+    """Return pre-interpolation indices whose next packet skips one sample.
+
+    A single dropped packet leaves a counter diff of 2, which the caller
+    interpolates. If ``source`` is given, also warn about **multi-packet** gaps
+    in ``[start_index, stop_index)`` -- a forward counter jump > 2 (the
+    ``< UINT32_WRAP // 2`` bound excludes the wrap, which is a large *backward*
+    jump, and a clean wrap is a diff of 1). Multi-packet gaps are NOT
+    interpolated: the timestamps stay correct (the regression maps the actual
+    counter to time) but the ephys data is discontinuous there.
+    """
     if stop_index is None:
         stop_index = raw_memmap.shape[0]
     if stop_index - start_index < 2:
@@ -85,9 +96,19 @@ def _find_single_dropped_packet_indices(
         timestamp_byte : timestamp_byte + TIMESTAMP_SIZE_BYTES,
     ]
     raw_uint32 = raw_uint8.view("uint8").reshape(-1, 4).view("uint32").reshape(-1)
-    return (
-        np.where(np.diff(raw_uint32) == EXPECTED_TIMESTAMP_DIFF_DROP)[0] + start_index
-    )
+    diffs = np.diff(raw_uint32)
+    if source is not None:
+        multi = diffs[
+            (diffs > EXPECTED_TIMESTAMP_DIFF_DROP) & (diffs < UINT32_WRAP // 2)
+        ]
+        if multi.size:
+            warn(
+                f"{multi.size} multi-packet gap(s) in the timestamp counter of "
+                f"{source} (largest {int(multi.max()) - 1} samples) are not "
+                "interpolated; the ephys data is discontinuous at those times.",
+                stacklevel=2,
+            )
+    return np.where(diffs == EXPECTED_TIMESTAMP_DIFF_DROP)[0] + start_index
 
 
 def _fit_systime_regression_streaming(
@@ -839,9 +860,11 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         if self.interpolate_dropped_packets and self.interpolate_index is None:
             # first call in a interpolation iterator, needs to find the dropped packets
-            # has to run through the entire file to find missing packets
+            # has to run through the entire file to find missing packets. Pass
+            # ``source`` so multi-packet gaps (not interpolated) are warned once
+            # per file here, rather than per partial.
             self.interpolate_index = _find_single_dropped_packet_indices(
-                self._raw_memmap, self._timestamp_byte
+                self._raw_memmap, self._timestamp_byte, source=self.filename
             )
             self._interpolate_raw_memmap()  # interpolates in the memmap
 

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -19,7 +19,6 @@ from neo.rawio.baserawio import (  # TODO the import location was updated for th
     _signal_stream_dtype,
     _spike_channel_dtype,
 )
-from scipy.stats import linregress
 
 INT_16_CONVERSION = 256
 BITS_PER_BYTE = 8
@@ -56,6 +55,126 @@ def _unwrap_uint32(values: np.ndarray) -> np.ndarray:
     offsets = np.zeros(unwrapped.size, dtype=np.int64)
     offsets[1:] = np.cumsum(wraps) * UINT32_WRAP
     return unwrapped + offsets
+
+
+def _fit_systime_regression_streaming(
+    read_counter,
+    read_sysclock,
+    n_total: int,
+    global_offset: int = 0,
+    chunk_size: int = 1 << 20,
+) -> tuple[float, float, np.ndarray]:
+    """Fit the Trodes-counter -> system-clock regression in one streaming pass.
+
+    Computes the same result as
+    ``linregress(_unwrap_uint32(counter).astype(float64), sysclock)`` together
+    with the list of global sample indices at which the uint32 counter wraps
+    (#169), but reads the data in ``chunk_size`` pieces via the
+    ``read_counter(i_start, i_stop)`` / ``read_sysclock(i_start, i_stop)``
+    callbacks instead of materialising the full ~15 GB arrays (#47).
+
+    The slope/intercept are accumulated with West's online covariance algorithm.
+    Both axes are shifted by their first sample (in int64, exactly) before
+    accumulating, because the raw system clock is ~1.7e18 ns -- float64 there has
+    only ~256 ns resolution, and West's incremental mean would accrue that error
+    across chunks. Shifting keeps the accumulated values small, then the
+    references are added back once at the end. The uint32 unwrap state -- the
+    cumulative number of wraps and the counter value carried across each chunk
+    boundary -- is threaded between chunks so the unwrapped axis and wrap-index
+    list match the whole-array computation exactly. Because floating-point
+    summation is not associative, the fitted slope/intercept differ from the
+    whole-array ``linregress`` only at the ~1e-16 relative level (sub-nanosecond
+    in the resulting timestamps).
+
+    Parameters
+    ----------
+    read_counter, read_sysclock : callable
+        ``f(i_start, i_stop) -> np.ndarray`` returning the raw uint32 counter and
+        the int64 system clock for ``[i_start, i_stop)``.
+    n_total : int
+        Total number of samples to fit over.
+    global_offset : int, optional
+        Sample index of ``i_start=0`` within the full recording, added to every
+        reported wrap index. By default 0.
+    chunk_size : int, optional
+        Number of samples read per step. By default ``2**20`` (~28 MB/chunk).
+
+    Returns
+    -------
+    tuple[float, float, np.ndarray]
+        ``(slope, intercept, wrap_sample_indices)``.
+    """
+    if n_total < 2:
+        raise ValueError("need at least 2 samples to fit the systime regression")
+
+    n_acc = 0
+    mean_x = mean_y = 0.0
+    sum_sq_dev_x = co_moment = 0.0  # West's M2 for x and the x-y co-moment
+    wrap_offset = 0  # cumulative number of 2**32 wraps seen so far
+    previous_last_counter = None  # final raw counter of the previous chunk
+    counter_reference = sysclock_reference = None  # x0, y0 (shift origin, exact)
+    wrap_sample_indices: list[int] = []
+
+    for start in range(0, n_total, chunk_size):
+        stop = min(start + chunk_size, n_total)
+        counter = np.asarray(read_counter(start, stop)).astype(np.int64)
+        sysclock = np.asarray(read_sysclock(start, stop)).astype(np.int64)
+
+        # An element is "after a wrap" when it drops by more than half the uint32
+        # range relative to its predecessor -- within the chunk, or across the
+        # boundary from the previous chunk's last sample.
+        is_after_wrap = np.zeros(counter.shape[0], dtype=np.int64)
+        if counter.shape[0] >= 2:
+            is_after_wrap[1:] = (np.diff(counter) < -(UINT32_WRAP // 2)).astype(
+                np.int64
+            )
+        if previous_last_counter is not None and (
+            counter[0] - previous_last_counter
+        ) < -(UINT32_WRAP // 2):
+            is_after_wrap[0] = 1
+
+        cumulative_wraps = np.cumsum(is_after_wrap)
+        counter_index = counter + (wrap_offset + cumulative_wraps) * UINT32_WRAP
+        wrap_sample_indices.extend(
+            (np.flatnonzero(is_after_wrap) + start + global_offset).tolist()
+        )
+        wrap_offset += int(cumulative_wraps[-1]) if cumulative_wraps.size else 0
+        previous_last_counter = int(counter[-1])
+
+        # Shift both axes by their first sample, in int64 (exact), before casting
+        # to float64 -- the raw sysclock (~1.7e18 ns) only has ~256 ns float64
+        # resolution, so accumulating it directly loses precision.
+        if counter_reference is None:
+            counter_reference = int(counter_index[0])
+            sysclock_reference = int(sysclock[0])
+        x = (counter_index - counter_reference).astype(np.float64)
+        y = (sysclock - sysclock_reference).astype(np.float64)
+
+        # West's online merge of this chunk's covariance statistics.
+        n_chunk = x.shape[0]
+        mean_x_chunk = float(x.mean())
+        mean_y_chunk = float(y.mean())
+        sum_sq_dev_x_chunk = float(((x - mean_x_chunk) ** 2).sum())
+        co_moment_chunk = float(((x - mean_x_chunk) * (y - mean_y_chunk)).sum())
+        if n_acc == 0:
+            n_acc = n_chunk
+            mean_x, mean_y = mean_x_chunk, mean_y_chunk
+            sum_sq_dev_x, co_moment = sum_sq_dev_x_chunk, co_moment_chunk
+        else:
+            n_new = n_acc + n_chunk
+            delta_x = mean_x_chunk - mean_x
+            delta_y = mean_y_chunk - mean_y
+            scale = n_acc * n_chunk / n_new
+            sum_sq_dev_x += sum_sq_dev_x_chunk + delta_x * delta_x * scale
+            co_moment += co_moment_chunk + delta_x * delta_y * scale
+            mean_x += delta_x * n_chunk / n_new
+            mean_y += delta_y * n_chunk / n_new
+            n_acc = n_new
+
+    slope = co_moment / sum_sq_dev_x
+    # Undo the shift: real means are the shifted means plus the references.
+    intercept = (mean_y + sysclock_reference) - slope * (mean_x + counter_reference)
+    return slope, intercept, np.asarray(wrap_sample_indices, dtype=np.int64)
 
 
 class SpikeGadgetsRawIO(BaseRawIO):
@@ -1031,52 +1150,46 @@ class SpikeGadgetsRawIO(BaseRawIO):
             A NumPy array containing the adjusted system timestamps.
         """
         NANOSECONDS_PER_SECOND = 1e9
-        # Get the raw uint32 Trodes timestamps for this slice. The counter wraps
-        # every 2**32 samples (~39.77 h at 30 kHz); unwrap to a globally
-        # monotonic axis anchored at the full recording's sample 0 so that split
-        # (partial) iterators -- which inherit the fitted slope/intercept and may
-        # read a post-wrap sub-range -- land on the same axis (see #169).
-        trodestime = np.asarray(self.get_analogsignal_timestamps(i_start, i_stop))
-        global_start = int(getattr(self, "_global_sample_offset", 0)) + int(
-            i_start or 0
-        )
+        # Fit the counter -> system-clock regression once, streaming over the
+        # whole recording so the fit never materialises the full counter/sysclock
+        # arrays (#47). Partial (split) iterators inherit these parameters and so
+        # skip the fit (see SpikeGadgetsRawIOPartial).
         if not self.regressed_systime_parameters:
-            # Fitting call (the full recording, in the normal pipeline). Unwrap
-            # this slice and record the global sample index of every wrap so
-            # partial iterators can reconstruct the identical axis.
-            trodestime_index = _unwrap_uint32(trodestime).astype(np.float64)
-            wrap_sample_indices = (
-                np.flatnonzero(
-                    np.diff(trodestime.astype(np.int64)) < -(UINT32_WRAP // 2)
-                )
-                + 1
-                + global_start
+            slope, intercept, wrap_sample_indices = _fit_systime_regression_streaming(
+                self.get_analogsignal_timestamps,
+                self.get_sys_clock,
+                n_total=self._raw_memmap.shape[0],
+                global_offset=int(getattr(self, "_global_sample_offset", 0)),
             )
-            # get raw systime values
-            systime_seconds = self.get_sys_clock(i_start, i_stop)
-            # regress
-            slope, intercept, _, _, _ = linregress(trodestime_index, systime_seconds)
             self.regressed_systime_parameters = {
                 "slope": slope,
                 "intercept": intercept,
                 "wrap_sample_indices": wrap_sample_indices,
             }
-        else:
-            slope = self.regressed_systime_parameters["slope"]
-            intercept = self.regressed_systime_parameters["intercept"]
-            wrap_sample_indices = self.regressed_systime_parameters.get(
-                "wrap_sample_indices", np.empty(0, dtype=np.int64)
-            )
-            # number of wraps before this slice's first global sample, plus any
-            # wrap occurring within the slice, recovers the global axis.
-            prior_wraps = int(
-                np.searchsorted(wrap_sample_indices, global_start, side="right")
-            )
-            trodestime_index = (
-                _unwrap_uint32(trodestime) + prior_wraps * UINT32_WRAP
-            ).astype(np.float64)
+        slope = self.regressed_systime_parameters["slope"]
+        intercept = self.regressed_systime_parameters["intercept"]
+        wrap_sample_indices = self.regressed_systime_parameters.get(
+            "wrap_sample_indices", np.empty(0, dtype=np.int64)
+        )
+
+        # Get the raw uint32 Trodes timestamps for this slice. The counter wraps
+        # every 2**32 samples (~39.77 h at 30 kHz); unwrap to the globally
+        # monotonic axis anchored at the full recording's sample 0. The number of
+        # wraps before this slice's first global sample, plus any wrap within the
+        # slice, recovers that axis so split (partial) iterators -- which may read
+        # a post-wrap sub-range -- land on the same axis (see #169).
+        trodestime = np.asarray(self.get_analogsignal_timestamps(i_start, i_stop))
+        global_start = int(getattr(self, "_global_sample_offset", 0)) + int(
+            i_start or 0
+        )
+        prior_wraps = int(
+            np.searchsorted(wrap_sample_indices, global_start, side="right")
+        )
+        trodestime_index = (
+            _unwrap_uint32(trodestime) + prior_wraps * UINT32_WRAP
+        ).astype(np.float64)
         adjusted_timestamps = intercept + slope * trodestime_index
-        return (adjusted_timestamps) / NANOSECONDS_PER_SECOND
+        return adjusted_timestamps / NANOSECONDS_PER_SECOND
 
     @functools.lru_cache(maxsize=1)
     def get_systime_from_trodes_timestamps(

--- a/src/trodes_to_nwb/spike_gadgets_raw_io.py
+++ b/src/trodes_to_nwb/spike_gadgets_raw_io.py
@@ -1408,9 +1408,22 @@ class SpikeGadgetsRawIOPartial(SpikeGadgetsRawIO):
         self.selected_streams = full_io.selected_streams
         self._generate_minimal_annotations()
         self.regressed_systime_parameters = full_io.regressed_systime_parameters
-        # this partial starts at start_index within the full recording; anchor
-        # the timestamp unwrap to the same global axis as the full-file fit.
-        self._global_sample_offset = start_index
+        # This partial starts at start_index within the full recording; anchor the
+        # timestamp unwrap to the same global axis as the full-file fit. The fit's
+        # wrap_sample_indices are on the POST-interpolation axis (get_regressed_systime
+        # resolves dropped-packet interpolation before fitting), but start_index is a
+        # PRE-interpolation index. If a dropped packet was inserted before a uint32
+        # wrap, leaving these on different axes undercounts prior_wraps and lands the
+        # partial ~39.77 h off. Translate start_index through the full file's
+        # interpolation map so both are post-interpolation (#47).
+        if isinstance(full_io._raw_memmap, InsertedMemmap):
+            self._global_sample_offset = int(
+                np.searchsorted(
+                    full_io._raw_memmap.mapped_index, start_index, side="left"
+                )
+            )
+        else:
+            self._global_sample_offset = start_index
 
         # crop key information to range of interest
         header_size = None

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -170,3 +170,84 @@ def test_selection_of_multiplexed_data():
             )
         )
         assert data.shape[1] == expected
+
+
+def test_ecu_analog_iterator_default_channel_order_uses_header_ids():
+    # The default channel order used to be np.arange(n_channel), which only works
+    # for streams whose channel IDs are numeric strings. ECU_analog IDs are names
+    # like "ECU_Ain1", so default construction should use the header IDs.
+    rec_file = data_path / "20230622_sample_01_a1.rec"
+    rec_dci = RecFileDataChunkIterator(
+        [rec_file],
+        stream_id="ECU_analog",
+        is_analog=True,
+    )
+
+    assert rec_dci._get_data((slice(0, 1), slice(0, 1))).shape == (1, 1)
+    assert rec_dci._get_data((slice(0, 1), slice(0, rec_dci.n_channel))).shape == (
+        1,
+        rec_dci.n_channel,
+    )
+
+
+def test_ecu_analog_iterator_open_ended_channel_slices():
+    rec_file = data_path / "20230622_sample_01_a1.rec"
+    rec_dci = RecFileDataChunkIterator(
+        [rec_file],
+        stream_id="ECU_analog",
+        is_analog=True,
+    )
+    total_time, total_channels = rec_dci._get_maxshape()
+
+    def expected_from_raw(time_slice, channel_slice):
+        start, stop, _ = time_slice.indices(total_time)
+        requested_channels = np.arange(total_channels)[channel_slice]
+        if stop <= start:
+            return np.empty((0, len(requested_channels)), dtype=np.int16)
+
+        physical_channels = requested_channels[requested_channels < rec_dci.n_channel]
+        channel_ids = [
+            str(channel)
+            for channel in np.asarray(rec_dci.nwb_hw_channel_order)[physical_channels]
+        ]
+        raw_data = rec_dci.neo_io[0].get_analogsignal_chunk(
+            block_index=rec_dci.block_index,
+            seg_index=rec_dci.seg_index,
+            i_start=start,
+            i_stop=stop,
+            stream_index=rec_dci.stream_index,
+            channel_ids=channel_ids,
+        )
+
+        physical_lookup = {
+            int(channel): index for index, channel in enumerate(physical_channels)
+        }
+        return_indices = [
+            (
+                physical_lookup[int(channel)]
+                if channel < rec_dci.n_channel
+                else len(physical_channels) + int(channel) - rec_dci.n_channel
+            )
+            for channel in requested_channels
+        ]
+        return (raw_data[:, return_indices] * rec_dci.conversion).astype("int16")
+
+    channel_slices = [
+        slice(None),
+        slice(0, None),
+        slice(rec_dci.n_channel, None),
+        slice(None, rec_dci.n_channel),
+        slice(None, None, 2),
+        slice(rec_dci.n_channel - 1, rec_dci.n_channel + 2),
+    ]
+    time_slices = [
+        slice(0, 3),
+        slice(total_time - 1, total_time),
+        slice(total_time, total_time),
+    ]
+    for time_slice in time_slices:
+        for channel_slice in channel_slices:
+            data = rec_dci._get_data((time_slice, channel_slice))
+            np.testing.assert_array_equal(
+                data, expected_from_raw(time_slice, channel_slice)
+            )

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -7,6 +7,7 @@ import pytest
 from trodes_to_nwb import convert_rec_header, convert_yaml
 from trodes_to_nwb.convert_ephys import (
     RecFileDataChunkIterator,
+    _is_non_decreasing,
     _is_strictly_increasing,
     _LazyTimestamps,
     add_raw_ephys,
@@ -67,6 +68,8 @@ def test_lazy_timestamps_matches_concatenation():
     # scalars
     for i in [0, boundary - 1, boundary, -1]:
         assert lazy[i] == expected[i]
+    # real rec timestamps are monotonic, so the non-decreasing check passes
+    assert lazy.is_non_decreasing() is True
 
 
 def test_lazy_timestamps_non_sysclock_fallback_matches():
@@ -159,6 +162,36 @@ def test_is_strictly_increasing_matches_full_diff():
     broken = increasing.copy()
     broken[2000] = broken[1999]
     assert _is_strictly_increasing(broken, 1000) is False
+
+
+def test_is_non_decreasing_matches_full_diff():
+    # The streaming non-decreasing check (np.digitize's precondition, #47) must
+    # agree with np.all(np.diff(...) >= 0): duplicates pass, only a decrease
+    # fails -- including a decrease landing exactly on a chunk boundary.
+    def reference(a):
+        return bool(np.all(np.diff(a) >= 0)) if len(a) > 1 else True
+
+    cases = [
+        np.arange(50, dtype=float),  # increasing
+        np.array([0.0, 1.0, 1.0, 2.0]),  # duplicates -> non-decreasing
+        np.array([0.0, 1.0, 2.0, 1.5, 3.0]),  # backward jump -> not
+        np.array([5.0]),  # single element
+        np.array([]),  # empty
+    ]
+    for values in cases:
+        for chunk in (3, 1_000_000):
+            assert _is_non_decreasing(values, chunk) == reference(values)
+
+    increasing = np.cumsum(np.abs(np.sin(np.arange(5000))) + 0.01)
+    assert _is_non_decreasing(increasing, 1000) is True
+    # a duplicate at the chunk boundary is still non-decreasing
+    dup = increasing.copy()
+    dup[2000] = dup[1999]
+    assert _is_non_decreasing(dup, 1000) is True
+    # a decrease at the chunk boundary is not
+    dec = increasing.copy()
+    dec[2000] = dec[1999] - 1.0
+    assert _is_non_decreasing(dec, 1000) is False
 
 
 def test_add_raw_ephys_single_rec():

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -123,6 +123,29 @@ def test_lazy_timestamps_chunk_iterator_roundtrip(tmp_path):
     np.testing.assert_array_equal(written, expected)
 
 
+def test_rec_file_data_chunk_iterator_single_sample_boundaries():
+    rec_dci = RecFileDataChunkIterator(
+        [
+            str(data_path / "20230622_sample_01_a1.rec"),
+            str(data_path / "20230622_sample_02_a1.rec"),
+        ],
+        stream_id="trodes",
+    )
+    boundary = rec_dci.n_time[0]
+    last = len(rec_dci.timestamps) - 1
+
+    for start in [0, boundary, last]:
+        out = rec_dci._get_data((slice(start, start + 1), slice(0, 1)))
+        assert out.shape == (1, 1)
+
+    first = rec_dci._get_data((slice(0, 1), slice(0, 1)))
+    first_two = rec_dci._get_data((slice(0, 2), slice(0, 1)))
+    np.testing.assert_array_equal(first, first_two[:1])
+
+    empty = rec_dci._get_data((slice(boundary, boundary), slice(0, 1)))
+    assert empty.shape == (0, 1)
+
+
 def test_lazy_timestamps_guards_fail_loud():
     # Array-like-but-not-an-array surfaces that should raise rather than silently
     # do the wrong/slow thing (#47 review hardening).

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -4,11 +4,37 @@ import numpy as np
 import pynwb
 
 from trodes_to_nwb import convert_rec_header, convert_yaml
-from trodes_to_nwb.convert_ephys import add_raw_ephys
+from trodes_to_nwb.convert_ephys import _is_strictly_increasing, add_raw_ephys
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
 
 MICROVOLTS_PER_VOLT = 1e6
+
+
+def test_is_strictly_increasing_matches_full_diff():
+    # The streaming check (#47, avoids the full np.diff for the ~15 GB timestamp
+    # array) must agree with np.all(np.diff(...) > 0) on every case, including
+    # violations that land exactly on a chunk boundary.
+    def reference(a):
+        return bool(np.all(np.diff(a) > 0)) if len(a) > 1 else True
+
+    cases = [
+        np.arange(50, dtype=float),  # strictly increasing
+        np.array([0.0, 1.0, 1.0, 2.0]),  # equal (not strict)
+        np.array([0.0, 1.0, 2.0, 1.5, 3.0]),  # backward jump
+        np.array([5.0]),  # single element
+        np.array([]),  # empty
+    ]
+    for values in cases:
+        for chunk in (3, 1_000_000):
+            assert _is_strictly_increasing(values, chunk) == reference(values)
+
+    # planted equal-value violation straddling a small chunk boundary
+    increasing = np.cumsum(np.abs(np.sin(np.arange(5000))) + 0.01)
+    assert _is_strictly_increasing(increasing, 1000) is True
+    broken = increasing.copy()
+    broken[2000] = broken[1999]
+    assert _is_strictly_increasing(broken, 1000) is False
 
 
 def test_add_raw_ephys_single_rec():

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -2,13 +2,133 @@ import os
 
 import numpy as np
 import pynwb
+import pytest
 
 from trodes_to_nwb import convert_rec_header, convert_yaml
-from trodes_to_nwb.convert_ephys import _is_strictly_increasing, add_raw_ephys
+from trodes_to_nwb.convert_ephys import (
+    RecFileDataChunkIterator,
+    _is_strictly_increasing,
+    _LazyTimestamps,
+    add_raw_ephys,
+)
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
 
 MICROVOLTS_PER_VOLT = 1e6
+
+
+def _sample_neo_io():
+    """neo_io list over the two-epoch sample rec files (for _LazyTimestamps tests)."""
+    recfile = [
+        data_path / "20230622_sample_01_a1.rec",
+        data_path / "20230622_sample_02_a1.rec",
+    ]
+    return RecFileDataChunkIterator(
+        [str(f) for f in recfile], stream_id="trodes"
+    ).neo_io
+
+
+def test_lazy_timestamps_matches_concatenation():
+    # _LazyTimestamps must be byte-identical to the old eager concatenation for
+    # every access pattern its consumers use -- this is the only *pytest* coverage
+    # of the slice/_gather plumbing (the golden master is a separate dev script).
+    neo_io = _sample_neo_io()
+    lazy = _LazyTimestamps(neo_io, use_sysclock=True)
+    expected = np.concatenate([io.get_regressed_systime(0, None) for io in neo_io])
+    boundary = neo_io[0]._raw_memmap.shape[0]
+
+    assert len(lazy) == expected.shape[0]
+    assert lazy.shape == expected.shape and lazy.dtype == expected.dtype
+    # full materialise
+    np.testing.assert_array_equal(np.asarray(lazy), expected)
+    # contiguous slices, including one straddling the file boundary
+    for s in [
+        slice(0, 10),
+        slice(boundary - 5, boundary + 5),
+        slice(len(lazy) - 3, len(lazy)),
+        slice(None, None),
+    ]:
+        np.testing.assert_array_equal(lazy[s], expected[s])
+    # integer fancy index: within one file, straddling the boundary, and negative
+    for idx in [
+        np.array([0, 1, 5, 1000, boundary - 1]),
+        np.array([boundary - 2, boundary, boundary + 50, len(lazy) - 1]),
+        np.array([-1, -2, 0, boundary]),
+    ]:
+        np.testing.assert_array_equal(lazy[idx], expected[idx])
+    # boolean mask
+    mask = np.zeros(len(lazy), dtype=bool)
+    mask[[3, boundary - 1, boundary, len(lazy) - 1]] = True
+    np.testing.assert_array_equal(lazy[mask], expected[mask])
+    # scalars
+    for i in [0, boundary - 1, boundary, -1]:
+        assert lazy[i] == expected[i]
+
+
+def test_lazy_timestamps_non_sysclock_fallback_matches():
+    # The use_sysclock=False branch (get_systime_from_trodes_timestamps) is never
+    # hit by the sample data through the normal path, so exercise its plumbing
+    # directly and assert byte-identity to the eager concatenation (#47).
+    neo_io = _sample_neo_io()
+    lazy = _LazyTimestamps(neo_io, use_sysclock=False)
+    expected = np.concatenate(
+        [io.get_systime_from_trodes_timestamps(0, None) for io in neo_io]
+    )
+    boundary = neo_io[0]._raw_memmap.shape[0]
+    np.testing.assert_array_equal(np.asarray(lazy), expected)
+    np.testing.assert_array_equal(
+        lazy[boundary - 5 : boundary + 5], expected[boundary - 5 : boundary + 5]
+    )
+    np.testing.assert_array_equal(
+        lazy[np.array([0, boundary, len(lazy) - 1])],
+        expected[np.array([0, boundary, len(lazy) - 1])],
+    )
+
+
+def test_lazy_timestamps_chunk_iterator_roundtrip(tmp_path):
+    # The chunked writer is the component whose whole purpose is the #47 memory
+    # win; round-trip it through a real HDF5 write and confirm the on-disk dataset
+    # equals the lazy array exactly.
+    from datetime import datetime
+
+    neo_io = _sample_neo_io()
+    lazy = _LazyTimestamps(neo_io, use_sysclock=True)
+    expected = np.asarray(lazy)
+
+    nwbfile = pynwb.NWBFile(
+        session_description="roundtrip",
+        identifier="roundtrip",
+        session_start_time=datetime(2023, 1, 1),
+    )
+    nwbfile.add_acquisition(
+        pynwb.TimeSeries(
+            name="lazy_ts",
+            data=lazy.as_data_chunk_iterator(),
+            rate=30000.0,
+            unit="seconds",
+        )
+    )
+    path = str(tmp_path / "lazy_ts_roundtrip.nwb")
+    with pynwb.NWBHDF5IO(path, "w") as io:
+        io.write(nwbfile)
+    with pynwb.NWBHDF5IO(path, "r", load_namespaces=True) as io:
+        written = io.read().acquisition["lazy_ts"].data[:]
+    np.testing.assert_array_equal(written, expected)
+
+
+def test_lazy_timestamps_guards_fail_loud():
+    # Array-like-but-not-an-array surfaces that should raise rather than silently
+    # do the wrong/slow thing (#47 review hardening).
+    lazy = _LazyTimestamps(_sample_neo_io(), use_sysclock=True)
+    n = len(lazy)
+    with pytest.raises(TypeError):
+        iter(lazy)  # would otherwise be O(n) disk reads via the sequence protocol
+    with pytest.raises(IndexError):
+        lazy[np.array([0, n])]  # fancy index out of bounds
+    with pytest.raises(IndexError):
+        lazy[n]  # scalar out of bounds
+    with pytest.raises(ValueError):
+        np.array(lazy, copy=False)  # no-copy view of a virtual array is impossible
 
 
 def test_is_strictly_increasing_matches_full_diff():

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -60,6 +60,10 @@ def test_lazy_timestamps_matches_concatenation():
     mask = np.zeros(len(lazy), dtype=bool)
     mask[[3, boundary - 1, boundary, len(lazy) - 1]] = True
     np.testing.assert_array_equal(lazy[mask], expected[mask])
+    # the capped-span (blocked) _gather path, forced via a small max_span, must
+    # be byte-identical to indexing the eager array (sparse, spanning both files)
+    sparse = np.arange(0, len(lazy), 997)
+    np.testing.assert_array_equal(lazy._gather(sparse, max_span=512), expected[sparse])
     # scalars
     for i in [0, boundary - 1, boundary, -1]:
         assert lazy[i] == expected[i]

--- a/src/trodes_to_nwb/tests/test_convert_intervals.py
+++ b/src/trodes_to_nwb/tests/test_convert_intervals.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pytest
 from pynwb import NWBHDF5IO
 
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
@@ -73,6 +74,47 @@ def test_trodes_sample_count_iterator_matches_concatenation():
     for chunk in iterator:
         materialized[chunk.selection] = chunk.data
     np.testing.assert_array_equal(materialized, expected)
+
+
+def test_trodes_sample_count_iterator_is_subscriptable():
+    # The non-PTP position path slices the streamed sample counts directly
+    # (sample_count[epoch_start:epoch_stop]); a bare GenericDataChunkIterator is
+    # not subscriptable, so the iterator exposes __len__/__getitem__ that match
+    # the materialized concatenation (issue #47, step 3).
+    recfile = [
+        data_path / "20230622_sample_01_a1.rec",
+        data_path / "20230622_sample_02_a1.rec",
+    ]
+    rec_dci = RecFileDataChunkIterator(recfile, stream_id="trodes")
+    expected = np.concatenate(
+        [io.get_analogsignal_timestamps(0, None) for io in rec_dci.neo_io]
+    )
+    iterator = _TrodesSampleCountIterator(rec_dci.neo_io)
+    boundary = rec_dci.neo_io[0]._raw_memmap.shape[0]
+
+    assert len(iterator) == expected.shape[0]
+
+    # slices: interior, cross-file-boundary, full, and the open-ended forms used
+    # by the position code
+    for s in [
+        slice(0, 10),
+        slice(boundary - 5, boundary + 5),
+        slice(100, 100),  # empty
+        slice(expected.shape[0] - 3, expected.shape[0]),
+        slice(None, None),
+        slice(boundary, None),
+    ]:
+        np.testing.assert_array_equal(iterator[s], expected[s])
+
+    # scalar access, including negative indexing
+    assert iterator[0] == expected[0]
+    assert iterator[boundary] == expected[boundary]
+    assert iterator[-1] == expected[-1]
+
+    with pytest.raises(IndexError):
+        iterator[expected.shape[0]]
+    with pytest.raises(TypeError):
+        iterator[1.5]
 
 
 def test_add_sample_count():

--- a/src/trodes_to_nwb/tests/test_convert_intervals.py
+++ b/src/trodes_to_nwb/tests/test_convert_intervals.py
@@ -4,7 +4,11 @@ import numpy as np
 from pynwb import NWBHDF5IO
 
 from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
-from trodes_to_nwb.convert_intervals import add_epochs, add_sample_count
+from trodes_to_nwb.convert_intervals import (
+    _TrodesSampleCountIterator,
+    add_epochs,
+    add_sample_count,
+)
 from trodes_to_nwb.convert_yaml import initialize_nwb, load_metadata
 from trodes_to_nwb.data_scanner import get_file_info
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
@@ -38,6 +42,37 @@ def test_add_epochs():
     assert list(epochs_df.tags) == [["01_a1"], ["02_a1"]]
     assert list(epochs_df.start_time) == [1687474797.888, 1687474821.109]
     assert list(epochs_df.stop_time) == list(old_epochs_df.stop_time)
+
+
+def test_trodes_sample_count_iterator_matches_concatenation():
+    # The streaming iterator must yield exactly the values, in order, that the old
+    # np.concatenate over the per-file Trodes sample counts produced -- including
+    # across the file boundary (issue #47).
+    recfile = [
+        data_path / "20230622_sample_01_a1.rec",
+        data_path / "20230622_sample_02_a1.rec",
+    ]
+    rec_dci = RecFileDataChunkIterator(recfile, stream_id="trodes")
+    expected = np.concatenate(
+        [io.get_analogsignal_timestamps(0, None) for io in rec_dci.neo_io]
+    )
+
+    iterator = _TrodesSampleCountIterator(rec_dci.neo_io)
+    assert iterator.maxshape == (expected.shape[0],)
+    assert iterator.dtype == np.uint32
+
+    # a chunk straddling the file boundary reads the right values
+    boundary = rec_dci.neo_io[0]._raw_memmap.shape[0]
+    np.testing.assert_array_equal(
+        iterator._get_data((slice(boundary - 5, boundary + 5),)),
+        expected[boundary - 5 : boundary + 5],
+    )
+
+    # full streamed reconstruction equals the concatenation
+    materialized = np.empty(expected.shape, dtype=np.uint32)
+    for chunk in iterator:
+        materialized[chunk.selection] = chunk.data
+    np.testing.assert_array_equal(materialized, expected)
 
 
 def test_add_sample_count():

--- a/src/trodes_to_nwb/tests/test_convert_intervals.py
+++ b/src/trodes_to_nwb/tests/test_convert_intervals.py
@@ -106,6 +106,9 @@ def test_trodes_sample_count_iterator_is_subscriptable():
     ]:
         np.testing.assert_array_equal(iterator[s], expected[s])
 
+    # a backward slice returns empty, like numpy (rather than crashing)
+    np.testing.assert_array_equal(iterator[5:1], expected[5:1])
+
     # scalar access, including negative indexing
     assert iterator[0] == expected[0]
     assert iterator[boundary] == expected[boundary]
@@ -115,6 +118,10 @@ def test_trodes_sample_count_iterator_is_subscriptable():
         iterator[expected.shape[0]]
     with pytest.raises(TypeError):
         iterator[1.5]
+    # a non-unit step would silently drop data, so it is rejected rather than
+    # quietly returning a contiguous (wrong) range
+    with pytest.raises(ValueError):
+        iterator[0:10:2]
 
 
 def test_add_sample_count():

--- a/src/trodes_to_nwb/tests/test_convert_position.py
+++ b/src/trodes_to_nwb/tests/test_convert_position.py
@@ -7,7 +7,10 @@ from pynwb import NWBHDF5IO
 from pynwb.behavior import Position
 
 from trodes_to_nwb import convert, convert_rec_header, convert_yaml
+from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator
+from trodes_to_nwb.convert_intervals import _TrodesSampleCountIterator
 from trodes_to_nwb.convert_position import (
+    _scalar_digitize,
     add_position,
     convert_datafile_to_pandas,
     correct_timestamps_for_camera_to_mcu_lag,
@@ -34,6 +37,83 @@ def test_wrapped_digitize():
     assert np.array_equal(wrapped_digitize(x, bins), expected)
     # test case no wrapping
     assert np.array_equal(wrapped_digitize(expected, expected), expected)
+
+
+def test_scalar_digitize_matches_np_digitize():
+    # _scalar_digitize replaces np.digitize(scalar, timestamps) in the non-PTP
+    # path so it can run over the lazy virtual timestamps without materialising
+    # the whole array (#47, step 3). It must return exactly np.digitize for both
+    # a plain ndarray and the lazy array, including below/at/above range and on
+    # an exact timestamp value.
+    ts = np.array([0.0, 1.0, 1.0, 2.5, 4.0, 9.0])  # monotonic, with a duplicate
+    probes = [-1.0, 0.0, 0.5, 1.0, 2.5, 3.0, 9.0, 100.0]
+    for value in probes:
+        assert _scalar_digitize(ts, value) == int(np.digitize(value, ts))
+
+    # lazy path (binary search via scalar reads) on the real sample timestamps
+    recfile = [
+        data_path / "20230622_sample_01_a1.rec",
+        data_path / "20230622_sample_02_a1.rec",
+    ]
+    rec_dci = RecFileDataChunkIterator([str(f) for f in recfile], stream_id="trodes")
+    lazy = rec_dci.timestamps
+    full = np.asarray(lazy)
+    boundary = rec_dci.neo_io[0]._raw_memmap.shape[0]
+    for value in [
+        full[0] - 1.0,
+        full[0],
+        full[5],
+        full[boundary - 1],
+        full[boundary],
+        full[len(full) // 2],
+        (full[10] + full[11]) / 2,
+        full[-1],
+        full[-1] + 1.0,
+    ]:
+        assert _scalar_digitize(lazy, float(value)) == int(np.digitize(value, full))
+
+
+def test_non_ptp_index_path_lazy_matches_materialized():
+    # End-to-end equivalence of the non-PTP index arithmetic on the LIVE lazy
+    # timestamps + streamed sample counts vs the materialized arrays. This is the
+    # path convert.py feeds at runtime (the non-PTP unit test uses materialized
+    # arrays, so this is the only coverage of the lazy/iterator path) (#47, step 3).
+    recfile = [
+        data_path / "20230622_sample_01_a1.rec",
+        data_path / "20230622_sample_02_a1.rec",
+    ]
+    rec_dci = RecFileDataChunkIterator([str(f) for f in recfile], stream_id="trodes")
+    lazy = rec_dci.timestamps
+    full = np.asarray(lazy)
+    sample_count = _TrodesSampleCountIterator(rec_dci.neo_io)
+    sample_count_full = np.concatenate(
+        [io.get_analogsignal_timestamps(0, None) for io in rec_dci.neo_io]
+    )
+
+    epoch_interval = [float(full[1000]), float(full[5000])]
+
+    start_live = _scalar_digitize(lazy, epoch_interval[0])
+    stop_live = _scalar_digitize(lazy, epoch_interval[1])
+    start_mat = int(np.digitize(epoch_interval[0], full))
+    stop_mat = int(np.digitize(epoch_interval[1], full))
+    assert (start_live, stop_live) == (start_mat, stop_mat)
+
+    # sample counts for the epoch, streamed vs concatenated
+    np.testing.assert_array_equal(
+        sample_count[start_live:stop_live], sample_count_full[start_mat:stop_mat]
+    )
+
+    # camera frames -> sample positions -> camera_systime (fancy index on lazy)
+    camera_counts = sample_count_full[start_mat:stop_mat][::37]
+    positions_live = (
+        wrapped_digitize(camera_counts, sample_count[start_live:stop_live]) + start_live
+    )
+    positions_mat = (
+        wrapped_digitize(camera_counts, sample_count_full[start_mat:stop_mat])
+        + start_mat
+    )
+    np.testing.assert_array_equal(positions_live, positions_mat)
+    np.testing.assert_array_equal(np.asarray(lazy[positions_live]), full[positions_mat])
 
 
 def test_parse_dtype_standard():

--- a/src/trodes_to_nwb/tests/test_convert_position.py
+++ b/src/trodes_to_nwb/tests/test_convert_position.py
@@ -78,6 +78,35 @@ def test_scalar_digitize_matches_np_digitize():
         assert _scalar_digitize(lazy, float(value)) == int(np.digitize(value, full))
 
 
+def test_scalar_digitize_lazy_fails_loud_on_decreasing_bins():
+    # The lazy path must preserve np.digitize's fail-loud on a decreasing array
+    # (a clock reset) -- the start<=end check alone misses it (e.g. [0,1,2,3,4,2]
+    # with epoch [2.5,3.5] returns ordered (3, 6)). A lazy-like object exposing
+    # is_non_decreasing() is checked; duplicates still pass (#47, review).
+    class _Bins:
+        def __init__(self, values, non_decreasing):
+            self._v = np.asarray(values, dtype=float)
+            self._nd = non_decreasing
+
+        def __len__(self):
+            return len(self._v)
+
+        def __getitem__(self, i):
+            return self._v[i]
+
+        def is_non_decreasing(self):
+            return self._nd
+
+    # a real backward jump -> raise (np.digitize would too)
+    with pytest.raises(ValueError):
+        _scalar_digitize(_Bins([0, 1, 2, 3, 4, 2], non_decreasing=False), 2.5)
+    # duplicates are allowed and give the same answer as np.digitize
+    dup = [0.0, 1.0, 1.0, 2.0, 3.0]
+    assert _scalar_digitize(_Bins(dup, non_decreasing=True), 1.0) == int(
+        np.digitize(1.0, dup)
+    )
+
+
 def test_non_ptp_index_path_lazy_matches_materialized():
     # End-to-end equivalence of the non-PTP index arithmetic on the LIVE lazy
     # timestamps + streamed sample counts vs the materialized arrays. This is the

--- a/src/trodes_to_nwb/tests/test_convert_position.py
+++ b/src/trodes_to_nwb/tests/test_convert_position.py
@@ -50,6 +50,11 @@ def test_scalar_digitize_matches_np_digitize():
     for value in probes:
         assert _scalar_digitize(ts, value) == int(np.digitize(value, ts))
 
+    # the ndarray path is plain np.digitize, so it keeps the fail-loud behaviour
+    # of raising on a non-monotonic array (rather than returning a bogus index)
+    with pytest.raises(ValueError):
+        _scalar_digitize(np.array([0.0, 5.0, 2.0, 9.0]), 3.0)
+
     # lazy path (binary search via scalar reads) on the real sample timestamps
     recfile = [
         data_path / "20230622_sample_01_a1.rec",

--- a/src/trodes_to_nwb/tests/test_spikegadgets_io.py
+++ b/src/trodes_to_nwb/tests/test_spikegadgets_io.py
@@ -1,8 +1,73 @@
 import numpy as np
 import pytest
+from scipy.stats import linregress
 
-from trodes_to_nwb.spike_gadgets_raw_io import InsertedMemmap, SpikeGadgetsRawIO
+from trodes_to_nwb.spike_gadgets_raw_io import (
+    UINT32_WRAP,
+    InsertedMemmap,
+    SpikeGadgetsRawIO,
+    _fit_systime_regression_streaming,
+    _unwrap_uint32,
+)
 from trodes_to_nwb.tests.utils import data_path
+
+
+def _whole_array_fit(counter, sysclock, global_offset=0):
+    """The pre-#47 whole-array fit, kept here as the reference to match."""
+    unwrapped = _unwrap_uint32(counter).astype(np.float64)
+    wraps = (
+        np.flatnonzero(np.diff(counter.astype(np.int64)) < -(UINT32_WRAP // 2))
+        + 1
+        + global_offset
+    )
+    slope, intercept, *_ = linregress(unwrapped, sysclock.astype(np.float64))
+    return slope, intercept, wraps
+
+
+@pytest.mark.parametrize("chunk_size", [7919, 50_000, 10**9])
+def test_streaming_fit_matches_whole_array_no_wrap(chunk_size):
+    # On real (non-wrapping) data, the streaming fit must reproduce the wrap list
+    # exactly and the resulting timestamps to well under one sample (#47).
+    io = SpikeGadgetsRawIO(filename=str(data_path / "20230622_sample_01_a1.rec"))
+    io.parse_header()
+    n = io._raw_memmap.shape[0]
+    counter = np.asarray(io.get_analogsignal_timestamps(0, None))
+    sysclock = io.get_sys_clock(0, None)
+    slope_ref, intercept_ref, wraps_ref = _whole_array_fit(counter, sysclock)
+
+    slope, intercept, wraps = _fit_systime_regression_streaming(
+        io.get_analogsignal_timestamps, io.get_sys_clock, n, 0, chunk_size
+    )
+    assert np.array_equal(wraps, wraps_ref)
+    unwrapped = _unwrap_uint32(counter).astype(np.float64)
+    ts_ref = (intercept_ref + slope_ref * unwrapped) / 1e9
+    ts = (intercept + slope * unwrapped) / 1e9
+    assert np.max(np.abs(ts - ts_ref)) < 1.0 / 30000  # < one 30 kHz sample
+
+
+@pytest.mark.parametrize("offset_from_wrap", [-1, 0, 1, 1000])
+def test_streaming_fit_handles_uint32_wrap_across_chunks(offset_from_wrap):
+    # Build a counter that wraps partway through; the chunk boundary is placed at
+    # / around the wrap to exercise the cross-chunk unwrap state. Wrap indices
+    # must be exact and the fit must match regardless of where chunks fall.
+    n = 30_000
+    raw = np.arange(n, dtype=np.int64) * 4 + 2**32 - 60_000
+    counter = (raw % UINT32_WRAP).astype(np.uint32)
+    unwrapped = _unwrap_uint32(counter).astype(np.float64)
+    sysclock = (123456789 + 33333.6 * unwrapped + np.sin(np.arange(n))).astype(np.int64)
+
+    slope_ref, intercept_ref, wraps_ref = _whole_array_fit(counter, sysclock, 1000)
+    assert wraps_ref.size >= 1  # the test data really does wrap
+    chunk_size = max(1, int(wraps_ref[0]) - 1000 + offset_from_wrap)
+
+    slope, intercept, wraps = _fit_systime_regression_streaming(
+        lambda a, b: counter[a:b], lambda a, b: sysclock[a:b], n, 1000, chunk_size
+    )
+    assert np.array_equal(wraps, wraps_ref)
+    ts_ref = (intercept_ref + slope_ref * unwrapped) / 1e9
+    ts = (intercept + slope * unwrapped) / 1e9
+    assert np.max(np.abs(ts - ts_ref)) < 1.0 / 30000
+
 
 # --- Fixture for SpikeGadgetsRawIO instance ---
 

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -178,6 +178,47 @@ def test_partial_offset_translates_to_post_interpolation_axis():
     )
 
 
+def test_partial_interpolates_drop_at_split_boundary():
+    # If a single dropped packet is represented by raw[stop - 1] -> raw[stop]
+    # with diff==2, a partial-local np.diff over raw[start:stop] cannot see it.
+    # The virtual packet belongs to the previous partial because full-file
+    # interpolation inserts it beside raw[stop - 1].
+    io = _synthetic_drop_before_wrap_io(n=400, drops=(179,), wrap_at=300)
+    full_ts = io.get_regressed_systime(0, None)
+
+    first = SpikeGadgetsRawIOPartial(io, start_index=0, stop_index=180)
+    second = SpikeGadgetsRawIOPartial(io, start_index=180, stop_index=360)
+
+    assert list(first.interpolate_index) == [179]
+    assert list(second.interpolate_index) == []
+    assert first._raw_memmap.shape[0] == 181
+    assert second._raw_memmap.shape[0] == 180
+
+    partial_ts = np.concatenate(
+        [
+            first.get_regressed_systime(0, None),
+            second.get_regressed_systime(0, None),
+        ]
+    )
+    expected_stop = int(np.searchsorted(io._raw_memmap.mapped_index, 360, side="left"))
+    np.testing.assert_allclose(partial_ts, full_ts[:expected_stop], rtol=0, atol=1e-6)
+
+
+def test_partial_detects_boundary_drop_without_full_interpolation_map():
+    # Non-sysclock split construction may create partials before the full file
+    # has resolved interpolation. The partial still needs one packet of lookahead
+    # to see a dropped packet at its final raw sample.
+    io = _synthetic_drop_before_wrap_io(n=400, drops=(179,), wrap_at=300)
+
+    first = SpikeGadgetsRawIOPartial(io, start_index=0, stop_index=180)
+    second = SpikeGadgetsRawIOPartial(io, start_index=180, stop_index=360)
+
+    assert list(first.interpolate_index) == [179]
+    assert list(second.interpolate_index) == []
+    assert first._raw_memmap.shape[0] == 181
+    assert second._raw_memmap.shape[0] == 180
+
+
 def test_non_wrapping_session_is_unchanged():
     # sanity: without a wrap, behaviour matches a plain float regression
     n = 500

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -14,8 +14,10 @@ import pytest
 from trodes_to_nwb.spike_gadgets_raw_io import (
     UINT32_WRAP,
     SpikeGadgetsRawIO,
+    SpikeGadgetsRawIOPartial,
     _unwrap_uint32,
 )
+from trodes_to_nwb.tests.utils import data_path
 
 FS = 30000.0  # Hz
 
@@ -117,6 +119,63 @@ def test_partial_after_wrap_lands_on_same_axis_as_full():
     out = partial.get_regressed_systime(0, None)
 
     np.testing.assert_allclose(out, expected[start:stop], rtol=0, atol=1e-6)
+
+
+def _synthetic_drop_before_wrap_io(n=500, drops=(50, 60, 70, 80, 90), wrap_at=300):
+    """A real SpikeGadgetsRawIO whose memmap is replaced with synthetic packets:
+    a uint32 counter with single dropped packets (diff==2) *before* a wrap, plus a
+    matching int64 sysclock. Built off a real .rec so the partial constructor (which
+    reads the file header and copies parsed attributes) works unchanged."""
+    io = SpikeGadgetsRawIO(filename=str(data_path / "20230622_sample_01_a1.rec"))
+    io.parse_header()
+    ts_byte, sys_byte, pkt = (
+        io._timestamp_byte,
+        io.sysClock_byte,
+        io._raw_memmap.shape[1],
+    )
+    drops = np.asarray(drops)
+    extra = np.zeros(n, dtype=np.int64)
+    for d in drops:
+        extra[d + 1 :] += 1  # a single dropped packet -> a +1 gap (counter diff 2)
+    unwrapped = np.arange(n, dtype=np.int64) + extra
+    unwrapped_global = (UINT32_WRAP - int(unwrapped[wrap_at])) + unwrapped
+    raw_counter = (unwrapped_global % UINT32_WRAP).astype("<u4")
+    sysclock = (1.7e18 + (1e9 / FS) * unwrapped_global).astype("<i8")
+
+    raw = np.zeros((n, pkt), dtype=np.uint8)
+    raw[:, ts_byte : ts_byte + 4] = raw_counter.view(np.uint8).reshape(n, 4)
+    raw[:, sys_byte : sys_byte + 8] = sysclock.view(np.uint8).reshape(n, 8)
+
+    io._raw_memmap = raw
+    io.interpolate_dropped_packets = True
+    io.interpolate_index = None
+    io.regressed_systime_parameters = {}
+    io._global_sample_offset = 0
+    return io
+
+
+def test_partial_offset_translates_to_post_interpolation_axis():
+    # A dropped-packet insertion BEFORE a uint32 wrap shifts the wrap onto the
+    # post-interpolation axis. A post-wrap partial inherits those (post-interp)
+    # wrap indices but its start_index is a pre-interpolation index; if the offset
+    # is not translated, prior_wraps is undercounted and the partial lands ~39.77 h
+    # off (one missed wrap). (#47 -- pre-existing interpolation x split x wrap bug.)
+    io = _synthetic_drop_before_wrap_io()
+    full_ts = io.get_regressed_systime(0, None)
+    assert np.all(np.diff(full_ts) > 0)  # monotonic across the drops and the wrap
+    # the wrap sits one sample later than its pre-interp index 300 (one insertion
+    # of the 5 drops is... all 5 are before it -> +5)
+    assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == [305]
+
+    start, stop = 302, 400  # a post-wrap partial; no drops in [start, stop)
+    partial = SpikeGadgetsRawIOPartial(io, start_index=start, stop_index=stop)
+    partial_ts = partial.get_regressed_systime(0, None)
+
+    # those pre-interp samples sit at these post-interp positions in the full file
+    post_offset = int(np.searchsorted(io._raw_memmap.mapped_index, start, side="left"))
+    np.testing.assert_array_equal(
+        partial_ts, full_ts[post_offset : post_offset + (stop - start)]
+    )
 
 
 def test_non_wrapping_session_is_unchanged():

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -46,7 +46,9 @@ def test_unwrap_multiple_wraps_is_monotonic():
     np.testing.assert_array_equal(out, true)
 
 
-@pytest.mark.parametrize("v", [np.array([], dtype=np.uint32), np.array([7], dtype=np.uint32)])
+@pytest.mark.parametrize(
+    "v", [np.array([], dtype=np.uint32), np.array([7], dtype=np.uint32)]
+)
 def test_unwrap_short_arrays(v):
     np.testing.assert_array_equal(_unwrap_uint32(v), v.astype(np.int64))
 

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from trodes_to_nwb.spike_gadgets_raw_io import (
+    InsertedMemmap,
     UINT32_WRAP,
     SpikeGadgetsRawIO,
     SpikeGadgetsRawIOPartial,
@@ -53,6 +54,28 @@ def test_unwrap_multiple_wraps_is_monotonic():
 )
 def test_unwrap_short_arrays(v):
     np.testing.assert_array_equal(_unwrap_uint32(v), v.astype(np.int64))
+
+
+@pytest.mark.parametrize("inserted", [(), (0,), (3,), (9,)])
+def test_inserted_memmap_open_ended_and_exact_boundary_slices(inserted):
+    raw = np.arange(10)[:, None]
+    inserted = np.asarray(inserted, dtype=int)
+    memmap = InsertedMemmap(raw, inserted)
+    expected = np.insert(np.arange(10), inserted, np.arange(10)[inserted])
+
+    for index in [
+        slice(None, 2),
+        slice(5, None),
+        slice(None, None),
+        slice(1, 3),
+        slice(3, 5),
+        slice(3, None),
+        slice(None, 3),
+        slice(2, 3),
+        slice(3, 3),
+        slice(None, None, 2),
+    ]:
+        np.testing.assert_array_equal(memmap[index].reshape(-1), expected[index])
 
 
 # --------------------------------------------------------------------------- #

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -128,3 +128,55 @@ def test_non_wrapping_session_is_unchanged():
 
     np.testing.assert_allclose(out, true / FS, rtol=0, atol=1e-9)
     assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == []
+
+
+def _fit_then_partial(raw, systime_ns, start, stop):
+    """Fit on the full recording, then read a [start, stop) partial that inherits
+    the fit (mirrors how split iterators are created)."""
+    full = _make_io(raw, systime_ns)
+    full.get_regressed_systime(0, None)  # fit; populates wrap_sample_indices
+    partial = _make_io(
+        raw[start:stop],
+        systime_ns[start:stop],  # unused once params are set, kept aligned
+        global_offset=start,
+        params=full.regressed_systime_parameters,
+    )
+    return partial.get_regressed_systime(0, None)
+
+
+def test_partial_straddling_the_wrap():
+    # a partial that *contains* the wrap: prior_wraps == 0, but the in-slice
+    # _unwrap_uint32 must detect the jump.
+    raw, systime_ns, expected = _wrapping_session()  # wrap at sample 500
+    out = _fit_then_partial(raw, systime_ns, 450, 650)
+    np.testing.assert_allclose(out, expected[450:650], rtol=0, atol=1e-6)
+
+
+def test_partial_starting_exactly_on_the_wrap():
+    # start == wrap_sample_index (500): the single case that distinguishes
+    # searchsorted side="right" (correct) from side="left" (off by one wrap).
+    raw, systime_ns, expected = _wrapping_session()
+    out = _fit_then_partial(raw, systime_ns, 500, 700)
+    np.testing.assert_allclose(out, expected[500:700], rtol=0, atol=1e-6)
+
+
+def _multi_wrap_session(n=300):
+    # large per-sample step so the counter wraps several times within n samples
+    step = UINT32_WRAP // 100
+    true = np.arange(n, dtype=np.int64) * step
+    raw = (true % UINT32_WRAP).astype(np.uint32)
+    systime_ns = true.astype(np.float64) * 1e9 / FS
+    return raw, systime_ns, true / FS
+
+
+def test_multi_wrap_full_and_partial():
+    raw, systime_ns, expected = _multi_wrap_session()  # ~2 wraps within the file
+    full = _make_io(raw, systime_ns)
+    out_full = full.get_regressed_systime(0, None)
+    assert np.all(np.diff(out_full) > 0)
+    np.testing.assert_allclose(out_full, expected, rtol=0, atol=1e-6)
+    assert len(full.regressed_systime_parameters["wrap_sample_indices"]) >= 2
+
+    # a partial after several wraps (prior_wraps == 2) must land on the same axis
+    out = _fit_then_partial(raw, systime_ns, 250, 300)
+    np.testing.assert_allclose(out, expected[250:300], rtol=0, atol=1e-6)

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -144,11 +144,17 @@ def test_partial_after_wrap_lands_on_same_axis_as_full():
     np.testing.assert_allclose(out, expected[start:stop], rtol=0, atol=1e-6)
 
 
-def _synthetic_drop_before_wrap_io(n=500, drops=(50, 60, 70, 80, 90), wrap_at=300):
-    """A real SpikeGadgetsRawIO whose memmap is replaced with synthetic packets:
-    a uint32 counter with single dropped packets (diff==2) *before* a wrap, plus a
-    matching int64 sysclock. Built off a real .rec so the partial constructor (which
-    reads the file header and copies parsed attributes) works unchanged."""
+def _io_from_unwrapped_counter(unwrapped_global):
+    """Build a real SpikeGadgetsRawIO whose memmap encodes a given monotonic int64
+    counter (wrapped to uint32) plus a matching linear int64 sysclock. Built off a
+    real .rec so SpikeGadgetsRawIOPartial's constructor (which reads the file
+    header and copies parsed attributes) works unchanged.
+
+    Gaps in ``unwrapped_global`` become gaps in the uint32 counter (dropped
+    packets); a value that crosses a multiple of 2**32 becomes a wrap.
+    """
+    unwrapped_global = np.asarray(unwrapped_global, dtype=np.int64)
+    n = unwrapped_global.size
     io = SpikeGadgetsRawIO(filename=str(data_path / "20230622_sample_01_a1.rec"))
     io.parse_header()
     ts_byte, sys_byte, pkt = (
@@ -156,12 +162,6 @@ def _synthetic_drop_before_wrap_io(n=500, drops=(50, 60, 70, 80, 90), wrap_at=30
         io.sysClock_byte,
         io._raw_memmap.shape[1],
     )
-    drops = np.asarray(drops)
-    extra = np.zeros(n, dtype=np.int64)
-    for d in drops:
-        extra[d + 1 :] += 1  # a single dropped packet -> a +1 gap (counter diff 2)
-    unwrapped = np.arange(n, dtype=np.int64) + extra
-    unwrapped_global = (UINT32_WRAP - int(unwrapped[wrap_at])) + unwrapped
     raw_counter = (unwrapped_global % UINT32_WRAP).astype("<u4")
     sysclock = (1.7e18 + (1e9 / FS) * unwrapped_global).astype("<i8")
 
@@ -175,6 +175,59 @@ def _synthetic_drop_before_wrap_io(n=500, drops=(50, 60, 70, 80, 90), wrap_at=30
     io.regressed_systime_parameters = {}
     io._global_sample_offset = 0
     return io
+
+
+def _synthetic_drop_before_wrap_io(n=500, drops=(50, 60, 70, 80, 90), wrap_at=300):
+    """A uint32 counter with single dropped packets (diff==2) *before* a wrap."""
+    extra = np.zeros(n, dtype=np.int64)
+    for d in np.asarray(drops):
+        extra[d + 1 :] += 1  # a single dropped packet -> a +1 gap (counter diff 2)
+    unwrapped = np.arange(n, dtype=np.int64) + extra
+    return _io_from_unwrapped_counter(
+        (UINT32_WRAP - int(unwrapped[wrap_at])) + unwrapped
+    )
+
+
+def test_multi_packet_drop_warns_and_is_not_interpolated():
+    # A 2-packet drop is a counter diff of 3 -- not a single drop. It is left as a
+    # gap (the regression maps the actual counter to time, so timestamps stay
+    # correct, but the ephys data is discontinuous) and warns once. Confirmed
+    # against Trodes: dropped = diff - 1, and multi-packet drops are real.
+    n = 400
+    unwrapped = np.arange(n, dtype=np.int64)
+    unwrapped[150:] += 2  # drop 2 packets after index 149 -> counter diff 3 there
+    io = _io_from_unwrapped_counter(unwrapped)  # small counter -> no wrap
+
+    with pytest.warns(UserWarning, match="multi-packet gap"):
+        ts = io.get_regressed_systime(0, None)  # triggers the interpolation resolve
+
+    assert list(io.interpolate_index) == []  # no single drops -> nothing inserted
+    assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == []
+    assert len(ts) == n  # the gap is NOT padded
+    assert np.all(np.diff(ts) > 0)  # still strictly increasing
+    # timestamps track the actual (gappy) counter, so the gap shows as a jump
+    expected = (1.7e18 + (1e9 / FS) * unwrapped) / 1e9
+    np.testing.assert_allclose(ts, expected, rtol=0, atol=1e-6)
+    assert (ts[150] - ts[149]) > 2 * (ts[1] - ts[0])  # multi-sample time jump
+
+
+def test_wrap_with_surrounding_gap_unwraps_to_monotonic_time():
+    # The record thread can drop packets right at a wrap (it resets its write
+    # buffer at the backward jump, recordThread.cpp). Such a wrap-with-gap must
+    # still unwrap to monotonic time and record exactly one wrap.
+    n = 400
+    unwrapped = np.arange(n, dtype=np.int64)
+    unwrapped[200:] += 5000  # a 5000-sample gap coinciding with the wrap
+    unwrapped_global = (UINT32_WRAP - int(unwrapped[200])) + unwrapped
+    io = _io_from_unwrapped_counter(unwrapped_global)
+
+    with pytest.warns(UserWarning, match="multi-packet gap"):  # the 5000 gap
+        ts = io.get_regressed_systime(0, None)
+
+    assert np.all(np.diff(ts) > 0)  # monotonic across the wrap-with-gap
+    assert len(io.regressed_systime_parameters["wrap_sample_indices"]) == 1
+    expected = (1.7e18 + (1e9 / FS) * unwrapped_global) / 1e9
+    np.testing.assert_allclose(ts, expected, rtol=0, atol=1e-6)
 
 
 def test_partial_offset_translates_to_post_interpolation_axis():

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -61,6 +61,9 @@ def _make_io(raw, systime_ns, global_offset=0, params=None):
     io = SpikeGadgetsRawIO.__new__(SpikeGadgetsRawIO)
     io.regressed_systime_parameters = {} if params is None else params
     io._global_sample_offset = global_offset
+    # get_regressed_systime drives its streaming fit from _raw_memmap.shape[0]
+    # (#47); for a real IO that equals the counter length, so mirror it here.
+    io._raw_memmap = np.empty((len(raw), 0), dtype=np.uint8)
 
     def _ts(i_start, i_stop):
         stop = len(raw) if i_stop is None else i_stop

--- a/src/trodes_to_nwb/tests/test_timestamp_wrap.py
+++ b/src/trodes_to_nwb/tests/test_timestamp_wrap.py
@@ -1,0 +1,128 @@
+"""uint32 Trodes-timestamp wrap handling in get_regressed_systime (#169).
+
+The Trodes per-packet timestamp is a uint32 sample counter that rolls over after
+2**32 samples (~39.77 h at 30 kHz). Casting it to float and regressing system
+time on it used to produce silently corrupt (non-monotonic) timestamps once a
+recording crossed the wrap. These tests cover the unwrap helper, the full-file
+fit across a wrap, and -- the subtle part -- that a post-wrap *partial* iterator
+(which inherits the full-file fit) lands on the same global time axis.
+"""
+
+import numpy as np
+import pytest
+
+from trodes_to_nwb.spike_gadgets_raw_io import (
+    UINT32_WRAP,
+    SpikeGadgetsRawIO,
+    _unwrap_uint32,
+)
+
+FS = 30000.0  # Hz
+
+
+# --------------------------------------------------------------------------- #
+# _unwrap_uint32
+# --------------------------------------------------------------------------- #
+def test_unwrap_no_wrap_is_identity():
+    v = np.array([10, 11, 12, 20], dtype=np.uint32)
+    np.testing.assert_array_equal(_unwrap_uint32(v), [10, 11, 12, 20])
+
+
+def test_unwrap_single_wrap():
+    v = np.array([UINT32_WRAP - 2, UINT32_WRAP - 1, 0, 1], dtype=np.uint32)
+    np.testing.assert_array_equal(
+        _unwrap_uint32(v),
+        [UINT32_WRAP - 2, UINT32_WRAP - 1, UINT32_WRAP, UINT32_WRAP + 1],
+    )
+
+
+def test_unwrap_multiple_wraps_is_monotonic():
+    # a monotone counter with a large per-sample step so it wraps several times
+    # within a small array (sample 5 crosses 2**32, sample 9 crosses 2*2**32)
+    true = np.arange(12, dtype=np.int64) * 10**9
+    wrapped = (true % UINT32_WRAP).astype(np.uint32)
+    out = _unwrap_uint32(wrapped)
+    assert np.all(np.diff(out) > 0)
+    np.testing.assert_array_equal(out, true)
+
+
+@pytest.mark.parametrize("v", [np.array([], dtype=np.uint32), np.array([7], dtype=np.uint32)])
+def test_unwrap_short_arrays(v):
+    np.testing.assert_array_equal(_unwrap_uint32(v), v.astype(np.int64))
+
+
+# --------------------------------------------------------------------------- #
+# get_regressed_systime through a wrap
+# --------------------------------------------------------------------------- #
+def _make_io(raw, systime_ns, global_offset=0, params=None):
+    """Build a bare SpikeGadgetsRawIO wired to fixed timestamp/sysclock arrays."""
+    io = SpikeGadgetsRawIO.__new__(SpikeGadgetsRawIO)
+    io.regressed_systime_parameters = {} if params is None else params
+    io._global_sample_offset = global_offset
+
+    def _ts(i_start, i_stop):
+        stop = len(raw) if i_stop is None else i_stop
+        return raw[i_start:stop]
+
+    def _sys(i_start, i_stop):
+        stop = len(systime_ns) if i_stop is None else i_stop
+        return systime_ns[i_start:stop]
+
+    io.get_analogsignal_timestamps = _ts
+    io.get_sys_clock = _sys
+    return io
+
+
+def _wrapping_session(n=1000, wrap_at=500):
+    """A recording whose uint32 counter wraps at sample `wrap_at`."""
+    true = (UINT32_WRAP - wrap_at) + np.arange(n, dtype=np.int64)  # global monotone
+    raw = (true % UINT32_WRAP).astype(np.uint32)
+    systime_ns = true.astype(np.float64) * 1e9 / FS
+    expected_seconds = true / FS
+    return raw, systime_ns, expected_seconds
+
+
+def test_full_file_regression_recovers_monotonic_time_across_wrap():
+    raw, systime_ns, expected = _wrapping_session()
+    io = _make_io(raw, systime_ns)
+
+    out = io.get_regressed_systime(0, None)
+
+    assert np.all(np.diff(out) > 0), "regressed time must be monotonic across the wrap"
+    np.testing.assert_allclose(out, expected, rtol=0, atol=1e-6)
+    # a wrap was recorded for partial iterators to use
+    assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == [500]
+
+
+def test_partial_after_wrap_lands_on_same_axis_as_full():
+    raw, systime_ns, expected = _wrapping_session()
+    full = _make_io(raw, systime_ns)
+    full.get_regressed_systime(0, None)  # fit; populates wrap_sample_indices
+
+    # a partial iterator covering a post-wrap sub-range [600, 800) inherits the
+    # fitted params and reads only its (small, post-wrap) raw counter values
+    start, stop = 600, 800
+    partial = _make_io(
+        raw[start:stop],
+        systime_ns[start:stop],  # unused (params already set) but keep aligned
+        global_offset=start,
+        params=full.regressed_systime_parameters,
+    )
+
+    out = partial.get_regressed_systime(0, None)
+
+    np.testing.assert_allclose(out, expected[start:stop], rtol=0, atol=1e-6)
+
+
+def test_non_wrapping_session_is_unchanged():
+    # sanity: without a wrap, behaviour matches a plain float regression
+    n = 500
+    true = 1_000 + np.arange(n, dtype=np.int64)
+    raw = true.astype(np.uint32)
+    systime_ns = true.astype(np.float64) * 1e9 / FS
+    io = _make_io(raw, systime_ns)
+
+    out = io.get_regressed_systime(0, None)
+
+    np.testing.assert_allclose(out, true / FS, rtol=0, atol=1e-9)
+    assert list(io.regressed_systime_parameters["wrap_sample_indices"]) == []


### PR DESCRIPTION
> **⚠️ Draft — not yet mergeable.** This is the `perf/47-full-integration` branch. It now sits on top of **#180 only** (merged in locally, still open as its own PR) — the uint32-wrap guard (`_unwrap_uint32`), which the #47 interpolation path calls directly, so it is a genuine dependency. The **analog layout (#168)** and the **position-integrity hardening (#181)** have both been removed from this branch (each lives in its own PR); #47 now carries only the timestamp-memory work plus the wrap/drop/split correctness that depends on #180. Once #180 lands on `main`, the #47 commits rebase onto `main` and this becomes a clean #47-only PR.
>
> **#47 is split across 3 PRs:**
> - **#196 (this one)** — the lazy-timestamps **core** + the wrap/drop/split correctness hardening it depends on.
> - **#195** — `sample_count` streaming slice (off `main`, independently mergeable).
> - **#197** — raw-IO/iterator hardening (off `main`, independently mergeable).
>
> The #195/#197 commits also live in this branch for now and dedupe on the rebase onto `main` (identical patch-ids).

## Problem
The converter chunks the ephys **data** but materialised the full **timestamps** array — `float64`, one per sample at 30 kHz, i.e. **~14.7 GB at 17 h** — and held it resident for the entire conversion (plus transient copies), OOMing ordinary machines (#47).

## What changed
Timestamps become **lazy/streamed**; the values are unchanged.
- **`_LazyTimestamps`** (`convert_ephys.py`): a 1-D `float64` virtual array that computes each slice / fancy-index / scalar on demand from the per-file counter→system-clock regression (or the Trodes-timestamp fallback). Byte-identical to the old `np.concatenate([... get_regressed_systime ...])`.
- **Chunked writers:** e-series, the first ECU-analog stream, and `sample_count` write their timestamps through a `GenericDataChunkIterator` instead of a resident array; hdmf's `docval` rejects a bare lazy array, so a small `_timestamps_for_write` wraps it (the analog writer is `main`'s combined-analog `TimeSeries`, now streamed).
- **Streaming regression fit** (`_fit_systime_regression_streaming`): OLS via West's online covariance in one chunked pass — never materialises the counter/sysclock arrays.
- **Streamed `sample_count`**, the strict-increasing monotonicity check, and the non-PTP position epoch index, all without materialising.

## Bugs fixed along the way (each with a failing-first test)
- uint32-wrap × interpolation × split: a post-wrap partial's `_global_sample_offset` is translated to the post-interpolation axis so it no longer lands ~39.77 h off (`106a6c2`).
- `InsertedMemmap` exact-stop / open-ended slicing (`3337aee`); single-dropped-packet interpolation at a split boundary (`1f68fd2`); non-PTP digitize now fails loud on decreasing bins like `np.digitize` (`d164bee`); multi-packet drops now warn (not interpolated) (`5bbbce9`).
- _(The `_get_data` boundary reads (`d680ef0`) and ECU_analog channel order/slices (`1cf5d68`) that previously lived here have moved to **#197**.)_

## Verification
- **Golden master:** `benchmarks/bench_47_timestamp_memory.py` sha1-fingerprints all **38** TimeSeries datasets of the sample conversion — **every one stays byte-identical**. #47 changes storage, not values.
- **Memory:** the old array held ~0.745 GiB at N=1e8 (→ ~13.7 GiB at 17 h); lazy build adds **0.000 GiB** and the streamed write peaks at **~0.1 GiB** (bounded by the buffer, independent of N).
- **Validated against the Trodes C++ source:** the load-bearing assumptions — uint32 sample counter wrapping at 2³², a single dropped packet == counter diff 2, sysClock = int64 ns, and the `.rec` packet layout — are confirmed in the acquisition code and the `.rec` write path.
- **Tests:** 188 passed / 16 skipped; `black` 26.5.1 clean. New tests cover `_LazyTimestamps` (slice/fancy/cross-boundary/non-sysClock/chunk round-trip), every boundary/interpolation/wrap fix, and the multi-drop warning.

## Known limitations
- Multi-packet drops (counter diff > 2) are not interpolated — the gap is kept (timestamps stay correct, ephys data is discontinuous there) and now warned.
- The non-sysClock fallback (`get_systime_from_trodes_timestamps`) lacks a real-data byte-identity test (no non-sysClock CI fixture).

## Before merge
Rebase the #47 commits onto `main` once **#180** (and, ideally, **#195 / #197**) land. The rebase drops the #180 merge content and — once #195/#197 are in `main` — their commits too (same patch-id). `spike_gadgets_raw_io.py` overlaps with #180 (the uint32-wrap guard) — reconcile there.

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



