### PR TITLE
raw-IO/iterator hardening: _get_data boundary reads + ECU_analog channel order/slices

### DIFF
--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -149,7 +149,10 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         if nwb_hw_channel_order is None:
             nwb_hw_channel_order = []
         if len(nwb_hw_channel_order) == 0:  # TODO: raise error instead?
-            self.nwb_hw_channel_order = np.arange(self.n_channel)
+            signal_channels = self.neo_io[0].header["signal_channels"]
+            self.nwb_hw_channel_order = signal_channels[
+                signal_channels["stream_id"] == self.stream_id
+            ]["id"]
         else:
             self.nwb_hw_channel_order = nwb_hw_channel_order
 
@@ -255,20 +258,21 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         # those are stored in the file as channel IDs
         # make into list form passed to neo_io
         selection_list = list(selection)
-        if self.is_analog:
-            selection_list[1] = slice(
-                selection[1].start,
-                min(selection[1].stop, self.n_channel),
-                selection[1].step,
-            )
-        channel_ids = [str(x) for x in self.nwb_hw_channel_order[selection_list[1]]]
         # what global index each file starts at
         file_start_ind = np.append(np.zeros(1, dtype=np.int64), np.cumsum(self.n_time))
         max_time, max_channel = self._get_maxshape()
+        requested_channels = np.arange(max_channel)[selection[1]]
+        if self.is_analog:
+            analog_channels = requested_channels[requested_channels < self.n_channel]
+            channel_ids = [
+                str(x) for x in np.asarray(self.nwb_hw_channel_order)[analog_channels]
+            ]
+        else:
+            selection_list[1] = selection[1]
+            channel_ids = [str(x) for x in self.nwb_hw_channel_order[selection_list[1]]]
         time_start, time_stop, _ = selection_list[0].indices(max_time)
         if time_stop <= time_start:
-            selected_channels = np.arange(max_channel)[selection[1]]
-            return np.empty((0, len(selected_channels)), dtype=np.int16)
+            return np.empty((0, len(requested_channels)), dtype=np.int16)
         data = []
         i = time_start
         while i < time_stop:
@@ -304,21 +308,20 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                 self.n_channel
             )  # number of non-multiplexed channels in the dataset
             n_analog_selected = data.shape[1] - n_multiplex
-            return_indices = np.arange(
-                n_analog_selected
-            )  # include all non-multiplexed channels pulled
-            # determine which multiplex channels are being requested
-            if (
-                selection[1].stop > n_analog
-            ):  # if multiplexed channels are being requested
-                requested_multiplex = np.arange(n_multiplex) + n_analog_selected
-                multiplex_slice = slice(
-                    max(selection[1].start - n_analog, 0),
-                    max(selection[1].stop - n_analog, 0),
-                    selection[1].step,
+            analog_lookup = {
+                int(channel): i
+                for i, channel in enumerate(
+                    requested_channels[requested_channels < n_analog]
                 )
-                requested_multiplex = requested_multiplex[multiplex_slice]
-                return_indices = np.append(return_indices, requested_multiplex)
+            }
+            return_indices = [
+                (
+                    analog_lookup[int(channel)]
+                    if channel < n_analog
+                    else n_analog_selected + int(channel) - n_analog
+                )
+                for channel in requested_channels
+            ]
             data = data[:, return_indices]
 
         return data

--- a/src/trodes_to_nwb/convert_ephys.py
+++ b/src/trodes_to_nwb/convert_ephys.py
@@ -263,38 +263,34 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
             )
         channel_ids = [str(x) for x in self.nwb_hw_channel_order[selection_list[1]]]
         # what global index each file starts at
-        file_start_ind = np.append(np.zeros(1), np.cumsum(self.n_time))
-        # the time indexes we want
-        time_index = np.arange(selection_list[0].start, selection_list[0].stop)[
-            :: selection_list[0].step
-        ]
+        file_start_ind = np.append(np.zeros(1, dtype=np.int64), np.cumsum(self.n_time))
+        max_time, max_channel = self._get_maxshape()
+        time_start, time_stop, _ = selection_list[0].indices(max_time)
+        if time_stop <= time_start:
+            selected_channels = np.arange(max_channel)[selection[1]]
+            return np.empty((0, len(selected_channels)), dtype=np.int16)
         data = []
-        i = time_index[0]
-        while i < min(time_index[-1], self._get_maxshape()[0]):
+        i = time_start
+        while i < time_stop:
             # find the stream where this piece of slice begins
-            io_stream = np.argmin(i >= file_start_ind) - 1
+            io_stream = np.searchsorted(file_start_ind, i, side="right") - 1
+            local_start = i - file_start_ind[io_stream]
+            local_stop = min(
+                time_stop - file_start_ind[io_stream],
+                self.n_time[io_stream],
+            )
             # get the data from that stream
             data.append(
                 self.neo_io[io_stream].get_analogsignal_chunk(
                     block_index=self.block_index,
                     seg_index=self.seg_index,
-                    i_start=int(i - file_start_ind[io_stream]),
-                    i_stop=int(
-                        min(
-                            time_index[-1] - file_start_ind[io_stream],
-                            self.n_time[io_stream],
-                        )
-                    )
-                    + 1,
+                    i_start=int(local_start),
+                    i_stop=int(local_stop),
                     stream_index=self.stream_index,
                     channel_ids=channel_ids,
                 )
             )
-            i += min(
-                self.n_time[io_stream]
-                - (i - file_start_ind[io_stream]),  # if added up to the end of stream
-                time_index[-1] - i,  # if finished in this stream
-            )
+            i = file_start_ind[io_stream] + local_stop
 
         data = (np.concatenate(data) * self.conversion).astype("int16")
         # Handle the appended multiplex data

--- a/src/trodes_to_nwb/tests/test_convert_analog.py
+++ b/src/trodes_to_nwb/tests/test_convert_analog.py
@@ -170,3 +170,84 @@ def test_selection_of_multiplexed_data():
             )
         )
         assert data.shape[1] == expected
+
+
+def test_ecu_analog_iterator_default_channel_order_uses_header_ids():
+    # The default channel order used to be np.arange(n_channel), which only works
+    # for streams whose channel IDs are numeric strings. ECU_analog IDs are names
+    # like "ECU_Ain1", so default construction should use the header IDs.
+    rec_file = data_path / "20230622_sample_01_a1.rec"
+    rec_dci = RecFileDataChunkIterator(
+        [rec_file],
+        stream_id="ECU_analog",
+        is_analog=True,
+    )
+
+    assert rec_dci._get_data((slice(0, 1), slice(0, 1))).shape == (1, 1)
+    assert rec_dci._get_data((slice(0, 1), slice(0, rec_dci.n_channel))).shape == (
+        1,
+        rec_dci.n_channel,
+    )
+
+
+def test_ecu_analog_iterator_open_ended_channel_slices():
+    rec_file = data_path / "20230622_sample_01_a1.rec"
+    rec_dci = RecFileDataChunkIterator(
+        [rec_file],
+        stream_id="ECU_analog",
+        is_analog=True,
+    )
+    total_time, total_channels = rec_dci._get_maxshape()
+
+    def expected_from_raw(time_slice, channel_slice):
+        start, stop, _ = time_slice.indices(total_time)
+        requested_channels = np.arange(total_channels)[channel_slice]
+        if stop <= start:
+            return np.empty((0, len(requested_channels)), dtype=np.int16)
+
+        physical_channels = requested_channels[requested_channels < rec_dci.n_channel]
+        channel_ids = [
+            str(channel)
+            for channel in np.asarray(rec_dci.nwb_hw_channel_order)[physical_channels]
+        ]
+        raw_data = rec_dci.neo_io[0].get_analogsignal_chunk(
+            block_index=rec_dci.block_index,
+            seg_index=rec_dci.seg_index,
+            i_start=start,
+            i_stop=stop,
+            stream_index=rec_dci.stream_index,
+            channel_ids=channel_ids,
+        )
+
+        physical_lookup = {
+            int(channel): index for index, channel in enumerate(physical_channels)
+        }
+        return_indices = [
+            (
+                physical_lookup[int(channel)]
+                if channel < rec_dci.n_channel
+                else len(physical_channels) + int(channel) - rec_dci.n_channel
+            )
+            for channel in requested_channels
+        ]
+        return (raw_data[:, return_indices] * rec_dci.conversion).astype("int16")
+
+    channel_slices = [
+        slice(None),
+        slice(0, None),
+        slice(rec_dci.n_channel, None),
+        slice(None, rec_dci.n_channel),
+        slice(None, None, 2),
+        slice(rec_dci.n_channel - 1, rec_dci.n_channel + 2),
+    ]
+    time_slices = [
+        slice(0, 3),
+        slice(total_time - 1, total_time),
+        slice(total_time, total_time),
+    ]
+    for time_slice in time_slices:
+        for channel_slice in channel_slices:
+            data = rec_dci._get_data((time_slice, channel_slice))
+            np.testing.assert_array_equal(
+                data, expected_from_raw(time_slice, channel_slice)
+            )

--- a/src/trodes_to_nwb/tests/test_convert_ephys.py
+++ b/src/trodes_to_nwb/tests/test_convert_ephys.py
@@ -4,7 +4,7 @@ import numpy as np
 import pynwb
 
 from trodes_to_nwb import convert_rec_header, convert_yaml
-from trodes_to_nwb.convert_ephys import add_raw_ephys
+from trodes_to_nwb.convert_ephys import RecFileDataChunkIterator, add_raw_ephys
 from trodes_to_nwb.tests.test_convert_rec_header import default_test_xml_tree
 from trodes_to_nwb.tests.utils import data_path
 
@@ -250,3 +250,26 @@ def test_add_raw_ephys_two_epoch():
             )
 
     os.remove(filename)
+
+
+def test_rec_file_data_chunk_iterator_single_sample_boundaries():
+    rec_dci = RecFileDataChunkIterator(
+        [
+            str(data_path / "20230622_sample_01_a1.rec"),
+            str(data_path / "20230622_sample_02_a1.rec"),
+        ],
+        stream_id="trodes",
+    )
+    boundary = rec_dci.n_time[0]
+    last = len(rec_dci.timestamps) - 1
+
+    for start in [0, boundary, last]:
+        out = rec_dci._get_data((slice(start, start + 1), slice(0, 1)))
+        assert out.shape == (1, 1)
+
+    first = rec_dci._get_data((slice(0, 1), slice(0, 1)))
+    first_two = rec_dci._get_data((slice(0, 2), slice(0, 1)))
+    np.testing.assert_array_equal(first, first_two[:1])
+
+    empty = rec_dci._get_data((slice(boundary, boundary), slice(0, 1)))
+    assert empty.shape == (0, 1)


### PR DESCRIPTION
## What
Two latent bugs in `RecFileDataChunkIterator._get_data`, fixed and covered by tests. Both are **independent of #47** (timestamp memory) and of #180/#181/#168 — this branch is off `main` and mergeable on its own. They were extracted out of `perf/47-full-integration` so that #47 stays scoped to the timestamp-memory work.

## Fixes
1. **Single-sample & cross-file boundary reads** (`cdde5cd`) — `_get_data` returned wrong-shaped output for a 1-sample slice, a slice straddling the file boundary, or an empty slice. Now each returns correctly-shaped data (`(1, k)`, the right cross-boundary values, and `(0, k)` for empty).
2. **ECU_analog default channel order + arbitrary channel slices** (`1a6f5b1`) — the default channel order was `np.arange(n_channel)`, which only works when channel IDs are numeric strings. `ECU_analog` IDs are names like `"ECU_Ain1"`, so default construction picked the wrong channels. Now it defaults to the header IDs and supports arbitrary / open-ended / stepped channel slices.

## Tests
- `test_rec_file_data_chunk_iterator_single_sample_boundaries` — boundary/empty/cross-file `_get_data` shapes.
- `test_ecu_analog_iterator_default_channel_order_uses_header_ids` — default ECU_analog construction reads real channels.
- `test_ecu_analog_iterator_open_ended_channel_slices` — `_get_data` output checked against the raw reader for a matrix of time × channel slices (incl. open-ended, stepped, out-of-range).

## Verification
`test_convert_ephys.py`, `test_convert_analog.py`, `test_convert_intervals.py`, `test_spikegadgets_io.py` all green; `black` 26.5.1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
